### PR TITLE
Fix bug with ES2015 default export wrapper components

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,4 @@
-.gitignore
+*.log
+.DS_Store
+coverage
+test/fixtures

--- a/lib/templates/default.js
+++ b/lib/templates/default.js
@@ -12,7 +12,11 @@ module.exports = data => {
     });
   }
   if (data.wrapper) {
-    modules += `const Wrapper = require('${data.wrapper}');\n`;
+    modules +=
+      `
+      let Wrapper = require('${data.wrapper}');
+      Wrapper = Wrapper.default || Wrapper;
+    `.trim() + '\n';
   }
 
   let body = data.jsx;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "precommit": "lint-staged",
-    "lint": "eslint *.js test lib",
+    "lint": "eslint .",
     "format": "prettier --single-quote --write '{,lib/**/,test/**/}*.js'",
     "test-jest": "jest",
     "pretest": "npm run lint",
@@ -64,7 +64,7 @@
     "react-dom": "^15.6.1"
   },
   "lint-staged": {
-    "{,lib/**/,test/**/}*.js": [
+    "**/*.js": [
       "eslint",
       "prettier --single-quote --write",
       "git add"
@@ -72,12 +72,10 @@
   },
   "jest": {
     "coverageReporters": [
-      "json",
-      "lcov",
       "text",
       "html"
     ],
-    "resetMocks": true,
+    "clearMocks": true,
     "roots": [
       "./test"
     ]

--- a/test/__snapshots__/to-component-module.test.js.snap
+++ b/test/__snapshots__/to-component-module.test.js.snap
@@ -89,7 +89,8 @@ quantity: 834
 const React = require(\\"react\\");
 const Timer = require(\\"./timer\\");
 import { Watcher } from \\"./watcher\\";
-const Wrapper = require(\\"../wrapper\\");
+let Wrapper = require(\\"../wrapper\\");
+Wrapper = Wrapper.default || Wrapper;
 
 const frontMatter = {
   title: \\"Everything is ok\\",
@@ -206,6 +207,20 @@ exports[`toComponentModule options.template 1`] = `
 `;
 
 exports[`toComponentModule options.wrapper 1`] = `
+"<div>
+    <div>This is the wrapper. Here are its props:</div>
+    <div>77</div>
+    <div>Everything is ok</div>
+    <div>834</div>
+    <div>
+        <h1>Everything is ok</h1>
+        <p>Some introductory text. The quantity is 834</p>
+        <p>Here is a number: 77</p>
+    </div>
+</div>"
+`;
+
+exports[`toComponentModule options.wrapper with ES2015 default export 1`] = `
 "<div>
     <div>This is the wrapper. Here are its props:</div>
     <div>77</div>

--- a/test/fixtures/.eslintrc
+++ b/test/fixtures/.eslintrc
@@ -1,7 +1,0 @@
-{
-  "parserOptions": {
-    "ecmaFeatures": {
-      "jsx": true
-    }
-  }
-}

--- a/test/fixtures/wrapper-es2015.js
+++ b/test/fixtures/wrapper-es2015.js
@@ -1,6 +1,4 @@
-'use strict';
-
-const React = require('react');
+import React from 'react';
 
 class Wrapper extends React.PureComponent {
   render() {
@@ -22,4 +20,4 @@ class Wrapper extends React.PureComponent {
   }
 }
 
-module.exports = Wrapper;
+export default Wrapper;

--- a/test/to-component-module.test.js
+++ b/test/to-component-module.test.js
@@ -200,6 +200,31 @@ describe('toComponentModule', () => {
     });
   });
 
+  test('options.wrapper with ES2015 default export', () => {
+    const text = prepText(`
+      ---
+      title: Everything is ok
+      quantity: 834
+      ---
+
+      # {{ frontMatter.title }}
+
+      Some introductory text. The quantity is {{ frontMatter.quantity }}
+
+      Here is a number: {{ props.number }}
+    `);
+    const options = {
+      wrapper: path.join(__dirname, './fixtures/wrapper-es2015.js')
+    };
+    const code = toComponentModule(text, options);
+    return loadOutputModule(code).then(Output => {
+      const rendered = renderComponent(Output, {
+        number: 77
+      });
+      expect(rendered).toMatchSnapshot();
+    });
+  });
+
   test('options.modules', () => {
     const text = prepText(`
       ---


### PR DESCRIPTION
Before this change, a wrapper component module with a ES2015 default would fail. This fixes that.

There's also a little housekeeping in here, which came up while fixing the bug.

@lshig for review.