### PR TITLE
Add precompile option

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ module.exports = MarkdownReact;
     - `name`: The value of the `name` option above, converted to PascalCase.
     - `frontMatter`: The parsed front matter.
     - `jsx`: The JSX string generated from your source Markdown.
+  - `precompile {?boolean}` - Default: `false`.
+    If `true`, the returned string will be compiled with Babel (using the ES2015 and React presets).
 
 For the default template, there are two special front matter properties that Markdown documets can use:
 - `wrapper`: Path to a wrapper component.

--- a/lib/to-component-module.js
+++ b/lib/to-component-module.js
@@ -1,6 +1,9 @@
 'use strict';
 
 const _ = require('lodash');
+const babel = require('babel-core');
+const presetEs2015 = require('babel-preset-es2015');
+const presetReact = require('babel-preset-react');
 const frontMatter = require('front-matter');
 const pascalCase = require('pascal-case');
 const toJsx = require('./to-jsx');
@@ -10,7 +13,8 @@ module.exports = (input, options) => {
   options = Object.assign(
     {
       name: 'MarkdownReact',
-      modules: []
+      modules: [],
+      precompile: false
     },
     options
   );
@@ -27,5 +31,7 @@ module.exports = (input, options) => {
   };
 
   if (options.template) return options.template(templateData);
-  return defaultTemplate(templateData);
+  const code = defaultTemplate(templateData);
+  if (!options.precompile) return code;
+  return babel.transform(code, { presets: [presetEs2015, presetReact] }).code;
 };

--- a/test/__snapshots__/to-component-module.test.js.snap
+++ b/test/__snapshots__/to-component-module.test.js.snap
@@ -198,6 +198,69 @@ module.exports = MySpecialName;
 "
 `;
 
+exports[`toComponentModule options.precompile = true 1`] = `
+"/*---
+title: Everything is ok
+---*/
+\\"use strict\\";
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var React = require(\\"react\\");
+
+var frontMatter = {
+  title: \\"Everything is ok\\"
+};
+
+var MarkdownReact = function (_React$PureComponent) {
+  _inherits(MarkdownReact, _React$PureComponent);
+
+  function MarkdownReact() {
+    _classCallCheck(this, MarkdownReact);
+
+    return _possibleConstructorReturn(this, (MarkdownReact.__proto__ || Object.getPrototypeOf(MarkdownReact)).apply(this, arguments));
+  }
+
+  _createClass(MarkdownReact, [{
+    key: \\"render\\",
+    value: function render() {
+      var props = this.props;
+      return React.createElement(
+        \\"div\\",
+        null,
+        React.createElement(
+          \\"h1\\",
+          null,
+          frontMatter.title
+        ),
+        React.createElement(
+          \\"p\\",
+          null,
+          \\"Some introductory text.\\"
+        )
+      );
+    }
+  }]);
+
+  return MarkdownReact;
+}(React.PureComponent);
+
+module.exports = MarkdownReact;"
+`;
+
+exports[`toComponentModule options.precompile = true 2`] = `
+"<div>
+    <h1>Everything is ok</h1>
+    <p>Some introductory text.</p>
+</div>"
+`;
+
 exports[`toComponentModule options.template 1`] = `
 "MarkdownReact
 {\\"title\\":\\"Foo\\",\\"list\\":[\\"one\\",\\"two\\"]}

--- a/test/to-component-module.test.js
+++ b/test/to-component-module.test.js
@@ -239,4 +239,25 @@ describe('toComponentModule', () => {
     const code = toComponentModule(text);
     expect(code).toMatchSnapshot();
   });
+
+  test('options.precompile = true', () => {
+    const text = prepText(`
+      ---
+      title: Everything is ok
+      ---
+
+      # {{ frontMatter.title }}
+
+      Some introductory text.
+    `);
+    const options = {
+      precompile: true
+    };
+    const code = toComponentModule(text, options);
+    expect(code).toMatchSnapshot();
+    return loadOutputModule(code).then(Output => {
+      const rendered = renderComponent(Output);
+      expect(rendered).toMatchSnapshot();
+    });
+  });
 });


### PR DESCRIPTION
This gives users the opportunity to precompile their template. The reasoning is that in some situations it might save the user an easy-to-forget step of passing the results of this module through Babel.

I thought about making the option default to `true` — but I'm annoyed at how bulky the Babel helpers are at the top of the compiled module and still hopeful that there's a better way. With `precompile: false`, at least it's on the user to decide how to do deal with those helpers.

@lshig for review.