### PR TITLE
 Add headings option to toComponentModule

### DIFF
--- a/packages/babel-plugin-transform-jsxtreme-markdown/CHANGELOG.md
+++ b/packages/babel-plugin-transform-jsxtreme-markdown/CHANGELOG.md
@@ -1,5 +1,7 @@
 # babel-plugin-transform-jsxtreme-markdown changelog
 
+Any version not listed here is just a non-disruptive update in the `@mapbox/jsxtreme-markdown` dependency.
+
 ## 0.4.3
 
 - Update dependencies.

--- a/packages/jsxtreme-markdown-loader/CHANGELOG.md
+++ b/packages/jsxtreme-markdown-loader/CHANGELOG.md
@@ -1,5 +1,9 @@
 # jsxtreme-markdown-loader changelog
 
+## 0.6.0
+
+- Update `@mapbox/jsxtreme-markdown` to get new `headings` option for `toComponentModule`.
+
 ## 0.5.4
 
 - Update dependencies.

--- a/packages/jsxtreme-markdown/CHANGELOG.md
+++ b/packages/jsxtreme-markdown/CHANGELOG.md
@@ -1,5 +1,9 @@
 # jsxtreme-markdown changelog
 
+## 0.8.0
+
+- Add `headings` option to `toComponentModule`.
+
 ## 0.7.4
 
 - Update dependencies.

--- a/packages/jsxtreme-markdown/README.md
+++ b/packages/jsxtreme-markdown/README.md
@@ -236,13 +236,6 @@ An array of lines of JS code that will be prepended to the top of the JavaScript
 The typical use-case is to `require` or `import` modules that will be used by interpolated JS and JSX.
 This value can be *added to* document-by-document by setting `prependJs` in the front matter of specific documents.
 
-##### name
-
-Type: `string`.
-Default: `MarkdownReact`.
-
-The name of the component class that will be generated.
-
 ##### template
 
 Type: `(data: Object) => string`.
@@ -259,12 +252,112 @@ The data object includes the following:
 - `frontMatter`: The parsed front matter.
 - `jsx`: The JSX string generated from your source Markdown.
 
+##### headings
+
+Type: `boolean`.
+Default: `false`.
+
+**The primary use case for the `headings` option is to build a table of contents in your wrapper component.**
+
+If `true`, the following will happen:
+
+- Every heading element in the Markdown will have an `id` attribute whose value is the element's slugified text.
+- The module's `frontMatter` object will be augmented with a `headings` array.
+  Each item in the array is an object with `text`, `slug`, and `level` properties.
+
+For example:
+
+```js
+const jsxtremeMarkdown = require('jsxtreme-markdown');
+
+const markdown = `
+  # One
+
+  Text.
+
+  ## Two
+
+  Some more text.
+
+  ### Third-level heading
+
+  Yet more.
+
+  ## Two
+
+  A section with a duplicate title.
+`;
+
+const js = jsxtremeMarkdown.toComponentModule(markdown);
+console.log(js);
+
+/*
+import React from "react";
+
+const frontMatter = {
+  headings: [
+    {
+      text: "One",
+      slug: "one",
+      level: 1
+    },
+    {
+      text: "Two",
+      slug: "two",
+      level: 2
+    },
+    {
+      text: "Third-level heading",
+      slug: "third-level-heading",
+      level: 3
+    },
+    {
+      text: "Two",
+      slug: "two-1",
+      level: 2
+    }
+  ]
+};
+
+export default class MarkdownReact extends React.PureComponent {
+  render() {
+    const props = this.props;
+    return (
+      <div>
+        <h1 id="one">One</h1>
+        <p>Text.</p>
+        <h2 id="two">Two</h2>
+        <p>Some more text.</p>
+        <h3 id="third-level-heading">Third-level heading</h3>
+        <p>Yet more.</p>
+        <h2 id="two-1">Two</h2>
+        <p>A section with a duplicate title.</p>
+      </div>
+    );
+  }
+}
+*/
+```
+
+
+A couple of things to keep in mind when using this option:
+
+- *Do not use interpolation in your heading text!*
+- Slugs are generated with [github-slugger], so should match the slugging patterns found in rendered Markdown files on GitHub.
+
 ##### precompile
 
 Type: `boolean`.
 Default: `false`.
 
 If `true`, the returned string will be compiled with Babel (using `babel-preset-env` and `babel-preset-react`).
+
+##### name
+
+Type: `string`.
+Default: `MarkdownReact`.
+
+The name of the component class that will be generated.
 
 #### The default template
 
@@ -283,3 +376,4 @@ For the default template, there are two special front matter properties that Mar
 [rehype]: https://github.com/wooorm/rehype
 [rehype plugins]: https://github.com/wooorm/rehype/blob/master/doc/plugins.md
 [htmltojsx]: https://www.npmjs.com/package/htmltojsx
+[github-slugger]: https://github.com/Flet/github-slugger

--- a/packages/jsxtreme-markdown/lib/remark-extract-headings.js
+++ b/packages/jsxtreme-markdown/lib/remark-extract-headings.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const _ = require('lodash');
+const visit = require('unist-util-visit');
+const nodeToString = require('mdast-util-to-string');
+const slugger = require('github-slugger')();
+
+let headings = [];
+
+function getHeadings() {
+  return headings;
+}
+
+function reset() {
+  headings = [];
+}
+
+function init() {
+  reset();
+  slugger.reset();
+}
+
+function plugin() {
+  return analyzer;
+
+  function analyzer(tree) {
+    init();
+    visit(tree, 'heading', node => {
+      const text = nodeToString(node).replace(/12345(\d+)54321/g, 'i$1');
+      const slug = slugger.slug(text);
+      headings.push({
+        text,
+        slug,
+        level: node.depth
+      });
+
+      _.set(node, ['data', 'id'], slug);
+      _.set(node, ['data', 'hProperties', 'id'], slug);
+    });
+  }
+}
+
+module.exports = {
+  plugin,
+  getHeadings,
+  reset
+};

--- a/packages/jsxtreme-markdown/lib/to-jsx.js
+++ b/packages/jsxtreme-markdown/lib/to-jsx.js
@@ -73,12 +73,13 @@ module.exports = (input, options) => {
   let result = jsx;
   Object.keys(placeholders).forEach(matchId => {
     const data = placeholders[matchId];
+    const representationRegExp = new RegExp(data.representation, 'g');
     if (!data.isTag) {
       // Expressions.
-      result = result.replace(data.representation, `{${data.value}}`);
+      result = result.replace(representationRegExp, `{${data.value}}`);
     } else if (data.isInline) {
       // Inline-level JSX elements.
-      result = result.replace(data.representation, data.value);
+      result = result.replace(representationRegExp, data.value);
     } else {
       // Block-level JSX elements.
       const blockPlaceholders = new RegExp(

--- a/packages/jsxtreme-markdown/package.json
+++ b/packages/jsxtreme-markdown/package.json
@@ -28,9 +28,11 @@
     "balanced-match": "^1.0.0",
     "block-elements": "^1.2.0",
     "front-matter": "^2.3.0",
+    "github-slugger": "^1.2.0",
     "htmltojsx": "^0.2.6",
     "line-column": "^1.0.2",
     "lodash": "^4.17.5",
+    "mdast-util-to-string": "^1.0.4",
     "pascal-case": "^2.0.1",
     "prettier": "^1.11.1",
     "rehype-raw": "^2.0.0",
@@ -38,7 +40,8 @@
     "remark-parse": "^5.0.0",
     "remark-rehype": "^3.0.0",
     "stringify-object": "^3.2.2",
-    "unified": "^6.1.6"
+    "unified": "^6.1.6",
+    "unist-util-visit": "^1.3.0"
   },
   "devDependencies": {
     "del": "^3.0.0",

--- a/packages/jsxtreme-markdown/test/__snapshots__/to-component-module.test.js.snap
+++ b/packages/jsxtreme-markdown/test/__snapshots__/to-component-module.test.js.snap
@@ -132,6 +132,133 @@ export default class MarkdownReact extends React.PureComponent {
 "
 `;
 
+exports[`toComponentModule options.headings 1`] = `
+"/*---
+title: Everything is ok
+---*/
+import React from \\"react\\";
+
+const frontMatter = {
+  title: \\"Everything is ok\\",
+  headings: [
+    {
+      text: \\"First heading\\",
+      slug: \\"first-heading\\",
+      level: 1
+    },
+    {
+      text: \\"Two\\",
+      slug: \\"two\\",
+      level: 2
+    },
+    {
+      text: \\"Two\\",
+      slug: \\"two-1\\",
+      level: 2
+    },
+    {
+      text: \\"Third heading, great\\",
+      slug: \\"third-heading-great\\",
+      level: 3
+    },
+    {
+      text: \\"With i89 interpolation\\",
+      slug: \\"with-i89-interpolation\\",
+      level: 1
+    }
+  ]
+};
+
+export default class MarkdownReact extends React.PureComponent {
+  render() {
+    const props = this.props;
+    return (
+      <div>
+        <h1 id=\\"first-heading\\">First heading</h1>
+        <p>Some introductory text.</p>
+        <h2 id=\\"two\\">Two</h2>
+        <h2 id=\\"two-1\\">Two</h2>
+        <h3 id=\\"third-heading-great\\">Third heading, great</h3>
+        <h1 id=\\"with-i89-interpolation\\">With {3} interpolation</h1>
+      </div>
+    );
+  }
+}
+"
+`;
+
+exports[`toComponentModule options.headings 2`] = `
+"<div>
+    <h1 id=\\"first-heading\\">First heading</h1>
+    <p>Some introductory text.</p>
+    <h2 id=\\"two\\">Two</h2>
+    <h2 id=\\"two-1\\">Two</h2>
+    <h3 id=\\"third-heading-great\\">Third heading, great</h3>
+    <h1 id=\\"with-i89-interpolation\\">With 3 interpolation</h1>
+</div>"
+`;
+
+exports[`toComponentModule options.headings README example 1`] = `
+"import React from \\"react\\";
+
+const frontMatter = {
+  headings: [
+    {
+      text: \\"One\\",
+      slug: \\"one\\",
+      level: 1
+    },
+    {
+      text: \\"Two\\",
+      slug: \\"two\\",
+      level: 2
+    },
+    {
+      text: \\"Third-level heading\\",
+      slug: \\"third-level-heading\\",
+      level: 3
+    },
+    {
+      text: \\"Two\\",
+      slug: \\"two-1\\",
+      level: 2
+    }
+  ]
+};
+
+export default class MarkdownReact extends React.PureComponent {
+  render() {
+    const props = this.props;
+    return (
+      <div>
+        <h1 id=\\"one\\">One</h1>
+        <p>Text.</p>
+        <h2 id=\\"two\\">Two</h2>
+        <p>Some more text.</p>
+        <h3 id=\\"third-level-heading\\">Third-level heading</h3>
+        <p>Yet more.</p>
+        <h2 id=\\"two-1\\">Two</h2>
+        <p>A section with a duplicate title.</p>
+      </div>
+    );
+  }
+}
+"
+`;
+
+exports[`toComponentModule options.headings README example 2`] = `
+"<div>
+    <h1 id=\\"one\\">One</h1>
+    <p>Text.</p>
+    <h2 id=\\"two\\">Two</h2>
+    <p>Some more text.</p>
+    <h3 id=\\"third-level-heading\\">Third-level heading</h3>
+    <p>Yet more.</p>
+    <h2 id=\\"two-1\\">Two</h2>
+    <p>A section with a duplicate title.</p>
+</div>"
+`;
+
 exports[`toComponentModule options.name 1`] = `
 "import React from \\"react\\";
 

--- a/packages/jsxtreme-markdown/test/to-component-module.test.js
+++ b/packages/jsxtreme-markdown/test/to-component-module.test.js
@@ -291,4 +291,59 @@ describe('toComponentModule', () => {
       expect(rendered).toMatchSnapshot();
     });
   });
+
+  test('options.headings', () => {
+    const text = prepText(`
+      ---
+      title: Everything is ok
+      ---
+
+      # First heading
+
+      Some introductory text.
+
+      ## Two
+      ## Two
+      ### Third heading, great
+      # With {{ 3 }} interpolation
+    `);
+    const options = {
+      headings: true
+    };
+    const code = toComponentModule(text, options);
+    expect(code).toMatchSnapshot();
+    return loadOutputModule(code).then(Output => {
+      const rendered = renderComponent(Output);
+      expect(rendered).toMatchSnapshot();
+    });
+  });
+
+  test('options.headings README example', () => {
+    const text = prepText(`
+      # One
+
+      Text.
+
+      ## Two
+
+      Some more text.
+
+      ### Third-level heading
+
+      Yet more.
+
+      ## Two
+
+      A section with a duplicate title.
+    `);
+    const options = {
+      headings: true
+    };
+    const code = toComponentModule(text, options);
+    expect(code).toMatchSnapshot();
+    return loadOutputModule(code).then(Output => {
+      const rendered = renderComponent(Output);
+      expect(rendered).toMatchSnapshot();
+    });
+  });
 });


### PR DESCRIPTION
The `headings` option help users build a table of contents in their Markdown wrapper component.

In the future I may want to figure out a way to expose an API for this kind of transformation, allowing the user to pass functions that would do this kind of thing. But for now, I think this will do.

cc @colleenmcginnis: this should lead to automated table-of-contents generation with Batfish.