### PR TITLE
Precompile loader output by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,9 @@
 			"integrity": "sha512-X3Ur/A/lIbbP8W0pmwgqtDXIxhQmxPaiwY9SKP7kF9wvZfjZRwMvbJE92ozUhF3UDK3DCKaV7oGqmI1rP/zqWA==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.2",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -29,7 +29,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.0"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -38,9 +38,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -55,7 +55,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -66,24 +66,24 @@
 			"integrity": "sha512-wbJpZFpqj07VIDnL1ZWnPdf5hl3rfCBYRAh5U+pb12OHwsgnAta/VTxwfHabopzDAh4AuHlhsNA/YEV4x4iVdw==",
 			"dev": true,
 			"requires": {
-				"autoprefixer": "8.2.0",
-				"concat-with-sourcemaps": "1.0.5",
-				"cp-file": "5.0.0",
-				"csso": "3.5.0",
-				"globby": "8.0.1",
-				"indent-string": "3.2.0",
-				"mkdirp": "0.5.1",
-				"optimize-js": "1.0.3",
-				"p-queue": "2.4.0",
-				"pify": "3.0.0",
-				"postcss": "6.0.21",
-				"postcss-custom-media": "6.0.0",
-				"postcss-custom-properties": "7.0.0",
-				"postcss-reporter": "5.0.0",
-				"strip-indent": "2.0.0",
-				"svgo": "1.0.5",
-				"svgstore": "2.0.3",
-				"uglify-js": "3.3.20"
+				"autoprefixer": "^8.2.0",
+				"concat-with-sourcemaps": "^1.0.4",
+				"cp-file": "^5.0.0",
+				"csso": "^3.5.0",
+				"globby": "^8.0.1",
+				"indent-string": "^3.1.0",
+				"mkdirp": "^0.5.1",
+				"optimize-js": "^1.0.2",
+				"p-queue": "^2.3.1",
+				"pify": "^3.0.0",
+				"postcss": "^6.0.8",
+				"postcss-custom-media": "^6.0.0",
+				"postcss-custom-properties": "^7.0.0",
+				"postcss-reporter": "^5.0.0",
+				"strip-indent": "^2.0.0",
+				"svgo": "^1.0.5",
+				"svgstore": "^2.0.3",
+				"uglify-js": "^3.3.16"
 			},
 			"dependencies": {
 				"globby": {
@@ -92,13 +92,13 @@
 					"integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
 					"dev": true,
 					"requires": {
-						"array-union": "1.0.2",
-						"dir-glob": "2.0.0",
-						"fast-glob": "2.2.0",
-						"glob": "7.1.2",
-						"ignore": "3.3.7",
-						"pify": "3.0.0",
-						"slash": "1.0.0"
+						"array-union": "^1.0.1",
+						"dir-glob": "^2.0.0",
+						"fast-glob": "^2.0.2",
+						"glob": "^7.1.2",
+						"ignore": "^3.3.5",
+						"pify": "^3.0.0",
+						"slash": "^1.0.0"
 					}
 				},
 				"indent-string": {
@@ -119,8 +119,8 @@
 					"integrity": "sha512-WpLkWCf9sGvGZnIvBV0PNID9BATQNT/IXKAmqegfKzIPcTmTV3FP8NQpoogQkt/Y402x2sOFdaHUmqFY9IZp+g==",
 					"dev": true,
 					"requires": {
-						"commander": "2.15.1",
-						"source-map": "0.6.1"
+						"commander": "~2.15.0",
+						"source-map": "~0.6.1"
 					}
 				}
 			}
@@ -131,8 +131,8 @@
 			"integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
 			"dev": true,
 			"requires": {
-				"call-me-maybe": "1.0.1",
-				"glob-to-regexp": "0.3.0"
+				"call-me-maybe": "^1.0.1",
+				"glob-to-regexp": "^0.3.0"
 			}
 		},
 		"JSONStream": {
@@ -141,8 +141,8 @@
 			"integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
 			"dev": true,
 			"requires": {
-				"jsonparse": "1.3.1",
-				"through": "2.3.8"
+				"jsonparse": "^1.2.0",
+				"through": ">=2.2.7 <3"
 			}
 		},
 		"abab": {
@@ -157,7 +157,7 @@
 			"integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
 			"dev": true,
 			"requires": {
-				"mime-types": "2.1.16",
+				"mime-types": "~2.1.11",
 				"negotiator": "0.6.1"
 			}
 		},
@@ -173,7 +173,7 @@
 			"integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
 			"dev": true,
 			"requires": {
-				"acorn": "4.0.13"
+				"acorn": "^4.0.3"
 			},
 			"dependencies": {
 				"acorn": {
@@ -190,7 +190,7 @@
 			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
 			"dev": true,
 			"requires": {
-				"acorn": "5.1.1"
+				"acorn": "^5.0.0"
 			}
 		},
 		"acorn-jsx": {
@@ -199,7 +199,7 @@
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
 			"dev": true,
 			"requires": {
-				"acorn": "3.3.0"
+				"acorn": "^3.0.4"
 			},
 			"dependencies": {
 				"acorn": {
@@ -222,10 +222,10 @@
 			"integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
 			"dev": true,
 			"requires": {
-				"co": "4.6.0",
-				"fast-deep-equal": "1.0.0",
-				"json-schema-traverse": "0.3.1",
-				"json-stable-stringify": "1.0.1"
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"json-schema-traverse": "^0.3.0",
+				"json-stable-stringify": "^1.0.1"
 			}
 		},
 		"ajv-keywords": {
@@ -240,9 +240,9 @@
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2",
-				"longest": "1.0.1",
-				"repeat-string": "1.6.1"
+				"kind-of": "^3.0.2",
+				"longest": "^1.0.1",
+				"repeat-string": "^1.5.2"
 			}
 		},
 		"amdefine": {
@@ -287,8 +287,8 @@
 			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
 			"dev": true,
 			"requires": {
-				"micromatch": "2.3.11",
-				"normalize-path": "2.1.1"
+				"micromatch": "^2.1.5",
+				"normalize-path": "^2.0.0"
 			},
 			"dependencies": {
 				"normalize-path": {
@@ -297,7 +297,7 @@
 					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 					"dev": true,
 					"requires": {
-						"remove-trailing-separator": "1.0.2"
+						"remove-trailing-separator": "^1.0.1"
 					}
 				}
 			}
@@ -314,7 +314,7 @@
 			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
 			"dev": true,
 			"requires": {
-				"default-require-extensions": "1.0.0"
+				"default-require-extensions": "^1.0.0"
 			}
 		},
 		"aproba": {
@@ -329,8 +329,8 @@
 			"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
 			"dev": true,
 			"requires": {
-				"delegates": "1.0.0",
-				"readable-stream": "2.3.3"
+				"delegates": "^1.0.0",
+				"readable-stream": "^2.0.6"
 			}
 		},
 		"argparse": {
@@ -339,7 +339,7 @@
 			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
 			"dev": true,
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"arr-diff": {
@@ -348,7 +348,7 @@
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 			"dev": true,
 			"requires": {
-				"arr-flatten": "1.1.0"
+				"arr-flatten": "^1.0.1"
 			}
 		},
 		"arr-flatten": {
@@ -393,7 +393,7 @@
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 			"dev": true,
 			"requires": {
-				"array-uniq": "1.0.3"
+				"array-uniq": "^1.0.1"
 			}
 		},
 		"array-uniq": {
@@ -426,9 +426,9 @@
 			"integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.7",
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0"
+				"bn.js": "^4.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0"
 			}
 		},
 		"assert": {
@@ -464,7 +464,7 @@
 			"integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
 			"dev": true,
 			"requires": {
-				"lodash": "4.17.5"
+				"lodash": "^4.14.0"
 			}
 		},
 		"async-each": {
@@ -497,12 +497,12 @@
 			"integrity": "sha512-xBVQpGAcSNNS1PBnEfT+F9VF8ZJeoKZ121I3OVQ0n1F0SqVuj4oLI6yFeEviPV8Z/GjoqBRXcYis0oSS8zjNEg==",
 			"dev": true,
 			"requires": {
-				"browserslist": "3.2.4",
-				"caniuse-lite": "1.0.30000827",
-				"normalize-range": "0.1.2",
-				"num2fraction": "1.2.2",
-				"postcss": "6.0.21",
-				"postcss-value-parser": "3.3.0"
+				"browserslist": "^3.2.0",
+				"caniuse-lite": "^1.0.30000817",
+				"normalize-range": "^0.1.2",
+				"num2fraction": "^1.2.2",
+				"postcss": "^6.0.20",
+				"postcss-value-parser": "^3.2.3"
 			},
 			"dependencies": {
 				"browserslist": {
@@ -511,8 +511,8 @@
 					"integrity": "sha512-Dwe62y/fNAcMfknzGJnkh7feISrrN0SmRvMFozb+Y2+qg7rfTIH5MS8yHzaIXcEWl8fPeIcdhZNQi1Lux+7dlg==",
 					"dev": true,
 					"requires": {
-						"caniuse-lite": "1.0.30000827",
-						"electron-to-chromium": "1.3.42"
+						"caniuse-lite": "^1.0.30000821",
+						"electron-to-chromium": "^1.3.41"
 					}
 				},
 				"caniuse-lite": {
@@ -547,93 +547,46 @@
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
+				"chalk": "^1.1.3",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.2"
 			}
 		},
 		"babel-core": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+			"version": "6.26.3",
+			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"babel-generator": "6.26.1",
-				"babel-helpers": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-register": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"convert-source-map": "1.5.0",
-				"debug": "2.6.8",
-				"json5": "0.5.1",
-				"lodash": "4.17.5",
-				"minimatch": "3.0.4",
-				"path-is-absolute": "1.0.1",
-				"private": "0.1.7",
-				"slash": "1.0.0",
-				"source-map": "0.5.6"
+				"babel-code-frame": "^6.26.0",
+				"babel-generator": "^6.26.0",
+				"babel-helpers": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-register": "^6.26.0",
+				"babel-runtime": "^6.26.0",
+				"babel-template": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"convert-source-map": "^1.5.1",
+				"debug": "^2.6.9",
+				"json5": "^0.5.1",
+				"lodash": "^4.17.4",
+				"minimatch": "^3.0.4",
+				"path-is-absolute": "^1.0.1",
+				"private": "^0.1.8",
+				"slash": "^1.0.0",
+				"source-map": "^0.5.7"
 			},
 			"dependencies": {
-				"babel-generator": {
-					"version": "6.26.1",
-					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-					"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-					"dev": true,
-					"requires": {
-						"babel-messages": "6.23.0",
-						"babel-runtime": "6.26.0",
-						"babel-types": "6.26.0",
-						"detect-indent": "4.0.0",
-						"jsesc": "1.3.0",
-						"lodash": "4.17.5",
-						"source-map": "0.5.7",
-						"trim-right": "1.0.1"
-					},
-					"dependencies": {
-						"source-map": {
-							"version": "0.5.7",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-							"dev": true
-						}
-					}
-				},
-				"babel-register": {
-					"version": "6.26.0",
-					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-					"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-					"dev": true,
-					"requires": {
-						"babel-core": "6.26.0",
-						"babel-runtime": "6.26.0",
-						"core-js": "2.5.4",
-						"home-or-tmp": "2.0.0",
-						"lodash": "4.17.5",
-						"mkdirp": "0.5.1",
-						"source-map-support": "0.4.15"
-					},
-					"dependencies": {
-						"core-js": {
-							"version": "2.5.4",
-							"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.4.tgz",
-							"integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA=",
-							"dev": true
-						}
-					}
-				},
 				"babel-runtime": {
 					"version": "6.26.0",
 					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 					"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 					"dev": true,
 					"requires": {
-						"core-js": "2.4.1",
-						"regenerator-runtime": "0.11.1"
+						"core-js": "^2.4.0",
+						"regenerator-runtime": "^0.11.0"
 					}
 				},
 				"babel-template": {
@@ -642,11 +595,11 @@
 					"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
 					"dev": true,
 					"requires": {
-						"babel-runtime": "6.26.0",
-						"babel-traverse": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"lodash": "4.17.5"
+						"babel-runtime": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"lodash": "^4.17.4"
 					}
 				},
 				"babel-traverse": {
@@ -655,15 +608,15 @@
 					"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
 					"dev": true,
 					"requires": {
-						"babel-code-frame": "6.26.0",
-						"babel-messages": "6.23.0",
-						"babel-runtime": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"debug": "2.6.8",
-						"globals": "9.18.0",
-						"invariant": "2.2.2",
-						"lodash": "4.17.5"
+						"babel-code-frame": "^6.26.0",
+						"babel-messages": "^6.23.0",
+						"babel-runtime": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"debug": "^2.6.8",
+						"globals": "^9.18.0",
+						"invariant": "^2.2.2",
+						"lodash": "^4.17.4"
 					}
 				},
 				"babel-types": {
@@ -672,16 +625,37 @@
 					"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 					"dev": true,
 					"requires": {
-						"babel-runtime": "6.26.0",
-						"esutils": "2.0.2",
-						"lodash": "4.17.5",
-						"to-fast-properties": "1.0.3"
+						"babel-runtime": "^6.26.0",
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.4",
+						"to-fast-properties": "^1.0.3"
 					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"private": {
+					"version": "0.1.8",
+					"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+					"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+					"dev": true
 				},
 				"regenerator-runtime": {
 					"version": "0.11.1",
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
 					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
 					"dev": true
 				}
 			}
@@ -692,14 +666,14 @@
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
 			"dev": true,
 			"requires": {
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"detect-indent": "4.0.0",
-				"jsesc": "1.3.0",
-				"lodash": "4.17.5",
-				"source-map": "0.5.7",
-				"trim-right": "1.0.1"
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"detect-indent": "^4.0.0",
+				"jsesc": "^1.3.0",
+				"lodash": "^4.17.4",
+				"source-map": "^0.5.7",
+				"trim-right": "^1.0.1"
 			},
 			"dependencies": {
 				"babel-runtime": {
@@ -708,8 +682,8 @@
 					"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 					"dev": true,
 					"requires": {
-						"core-js": "2.4.1",
-						"regenerator-runtime": "0.11.1"
+						"core-js": "^2.4.0",
+						"regenerator-runtime": "^0.11.0"
 					}
 				},
 				"babel-types": {
@@ -718,10 +692,10 @@
 					"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 					"dev": true,
 					"requires": {
-						"babel-runtime": "6.26.0",
-						"esutils": "2.0.2",
-						"lodash": "4.17.5",
-						"to-fast-properties": "1.0.3"
+						"babel-runtime": "^6.26.0",
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.4",
+						"to-fast-properties": "^1.0.3"
 					}
 				},
 				"regenerator-runtime": {
@@ -744,9 +718,9 @@
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
 			"dev": true,
 			"requires": {
-				"babel-helper-explode-assignable-expression": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-helper-explode-assignable-expression": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-builder-react-jsx": {
@@ -755,9 +729,9 @@
 			"integrity": "sha1-CteRfjPI11HmRtrKTnfMGTd9LLw=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0",
-				"esutils": "2.0.2"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1",
+				"esutils": "^2.0.0"
 			}
 		},
 		"babel-helper-call-delegate": {
@@ -766,10 +740,10 @@
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
 			"dev": true,
 			"requires": {
-				"babel-helper-hoist-variables": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-helper-hoist-variables": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-define-map": {
@@ -778,10 +752,10 @@
 			"integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0",
-				"lodash": "4.17.5"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1",
+				"lodash": "^4.2.0"
 			}
 		},
 		"babel-helper-explode-assignable-expression": {
@@ -790,9 +764,9 @@
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-function-name": {
@@ -801,11 +775,11 @@
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
 			"dev": true,
 			"requires": {
-				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-helper-get-function-arity": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-get-function-arity": {
@@ -814,8 +788,8 @@
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-hoist-variables": {
@@ -824,8 +798,8 @@
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-optimise-call-expression": {
@@ -834,8 +808,8 @@
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-regex": {
@@ -844,9 +818,9 @@
 			"integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0",
-				"lodash": "4.17.5"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1",
+				"lodash": "^4.2.0"
 			}
 		},
 		"babel-helper-remap-async-to-generator": {
@@ -855,11 +829,11 @@
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-replace-supers": {
@@ -868,12 +842,12 @@
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
 			"dev": true,
 			"requires": {
-				"babel-helper-optimise-call-expression": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-helper-optimise-call-expression": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helpers": {
@@ -882,18 +856,18 @@
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0"
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-jest": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.3.tgz",
-			"integrity": "sha512-BgSjmtl3mW3i+VeVHEr9d2zFSAT66G++pJcHQiUjd00pkW+voYXFctIm/indcqOWWXw5a1nUpR1XWszD9fJ1qg==",
+			"version": "23.0.1",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.0.1.tgz",
+			"integrity": "sha1-u6079SP7IC2gXtCmVAtIyE7tE6Y=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-istanbul": "4.1.5",
-				"babel-preset-jest": "22.4.3"
+				"babel-plugin-istanbul": "^4.1.6",
+				"babel-preset-jest": "^23.0.1"
 			}
 		},
 		"babel-loader": {
@@ -902,9 +876,9 @@
 			"integrity": "sha512-/hbyEvPzBJuGpk9o80R0ZyTej6heEOr59GoEUtn8qFKbnx4cJm9FWES6J/iv644sYgrtVw9JJQkjaLW/bqb5gw==",
 			"dev": true,
 			"requires": {
-				"find-cache-dir": "1.0.0",
-				"loader-utils": "1.1.0",
-				"mkdirp": "0.5.1"
+				"find-cache-dir": "^1.0.0",
+				"loader-utils": "^1.0.2",
+				"mkdirp": "^0.5.1"
 			}
 		},
 		"babel-messages": {
@@ -913,7 +887,7 @@
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-check-es2015-constants": {
@@ -922,24 +896,25 @@
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-istanbul": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz",
-			"integrity": "sha1-Z2DN2Xf0EdPhdbsGTyvDJ9mbK24=",
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
 			"dev": true,
 			"requires": {
-				"find-up": "2.1.0",
-				"istanbul-lib-instrument": "1.10.1",
-				"test-exclude": "4.2.1"
+				"babel-plugin-syntax-object-rest-spread": "^6.13.0",
+				"find-up": "^2.1.0",
+				"istanbul-lib-instrument": "^1.10.1",
+				"test-exclude": "^4.2.1"
 			}
 		},
 		"babel-plugin-jest-hoist": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.3.tgz",
-			"integrity": "sha512-zhvv4f6OTWy2bYevcJftwGCWXMFe7pqoz41IhMi4xna7xNsX5NygdagsrE0y6kkfuXq8UalwvPwKTyAxME2E/g==",
+			"version": "23.0.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.0.1.tgz",
+			"integrity": "sha1-6qEclkVjrqnCG+zvK994U/fzwUg=",
 			"dev": true
 		},
 		"babel-plugin-syntax-async-functions": {
@@ -984,9 +959,9 @@
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
 			"dev": true,
 			"requires": {
-				"babel-helper-remap-async-to-generator": "6.24.1",
-				"babel-plugin-syntax-async-functions": "6.13.0",
-				"babel-runtime": "6.25.0"
+				"babel-helper-remap-async-to-generator": "^6.24.1",
+				"babel-plugin-syntax-async-functions": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-arrow-functions": {
@@ -995,7 +970,7 @@
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoped-functions": {
@@ -1004,7 +979,7 @@
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoping": {
@@ -1013,11 +988,11 @@
 			"integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0",
-				"lodash": "4.17.5"
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1",
+				"lodash": "^4.2.0"
 			}
 		},
 		"babel-plugin-transform-es2015-classes": {
@@ -1026,15 +1001,15 @@
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
 			"dev": true,
 			"requires": {
-				"babel-helper-define-map": "6.24.1",
-				"babel-helper-function-name": "6.24.1",
-				"babel-helper-optimise-call-expression": "6.24.1",
-				"babel-helper-replace-supers": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-helper-define-map": "^6.24.1",
+				"babel-helper-function-name": "^6.24.1",
+				"babel-helper-optimise-call-expression": "^6.24.1",
+				"babel-helper-replace-supers": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-computed-properties": {
@@ -1043,8 +1018,8 @@
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0"
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-destructuring": {
@@ -1053,7 +1028,7 @@
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-duplicate-keys": {
@@ -1062,8 +1037,8 @@
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-for-of": {
@@ -1072,7 +1047,7 @@
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-function-name": {
@@ -1081,9 +1056,9 @@
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-literals": {
@@ -1092,7 +1067,7 @@
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-amd": {
@@ -1101,9 +1076,9 @@
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0"
+				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
@@ -1112,10 +1087,10 @@
 			"integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-strict-mode": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-plugin-transform-strict-mode": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-systemjs": {
@@ -1124,9 +1099,9 @@
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
 			"dev": true,
 			"requires": {
-				"babel-helper-hoist-variables": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0"
+				"babel-helper-hoist-variables": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-umd": {
@@ -1135,9 +1110,9 @@
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0"
+				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-object-super": {
@@ -1146,8 +1121,8 @@
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
 			"dev": true,
 			"requires": {
-				"babel-helper-replace-supers": "6.24.1",
-				"babel-runtime": "6.25.0"
+				"babel-helper-replace-supers": "^6.24.1",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-parameters": {
@@ -1156,12 +1131,12 @@
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
 			"dev": true,
 			"requires": {
-				"babel-helper-call-delegate": "6.24.1",
-				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-helper-call-delegate": "^6.24.1",
+				"babel-helper-get-function-arity": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-shorthand-properties": {
@@ -1170,8 +1145,8 @@
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-spread": {
@@ -1180,7 +1155,7 @@
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-sticky-regex": {
@@ -1189,9 +1164,9 @@
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
 			"dev": true,
 			"requires": {
-				"babel-helper-regex": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-helper-regex": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-template-literals": {
@@ -1200,7 +1175,7 @@
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-typeof-symbol": {
@@ -1209,7 +1184,7 @@
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-unicode-regex": {
@@ -1218,9 +1193,9 @@
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
 			"dev": true,
 			"requires": {
-				"babel-helper-regex": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"regexpu-core": "2.0.0"
+				"babel-helper-regex": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"regexpu-core": "^2.0.0"
 			}
 		},
 		"babel-plugin-transform-exponentiation-operator": {
@@ -1229,9 +1204,9 @@
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
 			"dev": true,
 			"requires": {
-				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
-				"babel-runtime": "6.25.0"
+				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-flow-strip-types": {
@@ -1240,8 +1215,8 @@
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-flow": "6.18.0",
-				"babel-runtime": "6.25.0"
+				"babel-plugin-syntax-flow": "^6.18.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-react-display-name": {
@@ -1250,7 +1225,7 @@
 			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx": {
@@ -1259,9 +1234,9 @@
 			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
 			"dev": true,
 			"requires": {
-				"babel-helper-builder-react-jsx": "6.24.1",
-				"babel-plugin-syntax-jsx": "6.18.0",
-				"babel-runtime": "6.25.0"
+				"babel-helper-builder-react-jsx": "^6.24.1",
+				"babel-plugin-syntax-jsx": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx-self": {
@@ -1270,8 +1245,8 @@
 			"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-jsx": "6.18.0",
-				"babel-runtime": "6.25.0"
+				"babel-plugin-syntax-jsx": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx-source": {
@@ -1280,8 +1255,8 @@
 			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-jsx": "6.18.0",
-				"babel-runtime": "6.25.0"
+				"babel-plugin-syntax-jsx": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-regenerator": {
@@ -1299,8 +1274,8 @@
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-preset-env": {
@@ -1309,36 +1284,36 @@
 			"integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-check-es2015-constants": "6.22.0",
-				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
-				"babel-plugin-transform-async-to-generator": "6.24.1",
-				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "6.24.1",
-				"babel-plugin-transform-es2015-classes": "6.24.1",
-				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
-				"babel-plugin-transform-es2015-destructuring": "6.23.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-				"babel-plugin-transform-es2015-for-of": "6.23.0",
-				"babel-plugin-transform-es2015-function-name": "6.24.1",
-				"babel-plugin-transform-es2015-literals": "6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-				"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-				"babel-plugin-transform-es2015-modules-umd": "6.24.1",
-				"babel-plugin-transform-es2015-object-super": "6.24.1",
-				"babel-plugin-transform-es2015-parameters": "6.24.1",
-				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-				"babel-plugin-transform-es2015-spread": "6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-				"babel-plugin-transform-es2015-template-literals": "6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-				"babel-plugin-transform-exponentiation-operator": "6.24.1",
-				"babel-plugin-transform-regenerator": "6.24.1",
-				"browserslist": "2.3.0",
-				"invariant": "2.2.2",
-				"semver": "5.4.1"
+				"babel-plugin-check-es2015-constants": "^6.22.0",
+				"babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+				"babel-plugin-transform-async-to-generator": "^6.22.0",
+				"babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+				"babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+				"babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+				"babel-plugin-transform-es2015-classes": "^6.23.0",
+				"babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+				"babel-plugin-transform-es2015-destructuring": "^6.23.0",
+				"babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+				"babel-plugin-transform-es2015-for-of": "^6.23.0",
+				"babel-plugin-transform-es2015-function-name": "^6.22.0",
+				"babel-plugin-transform-es2015-literals": "^6.22.0",
+				"babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+				"babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+				"babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+				"babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+				"babel-plugin-transform-es2015-object-super": "^6.22.0",
+				"babel-plugin-transform-es2015-parameters": "^6.23.0",
+				"babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+				"babel-plugin-transform-es2015-spread": "^6.22.0",
+				"babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+				"babel-plugin-transform-es2015-template-literals": "^6.22.0",
+				"babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+				"babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+				"babel-plugin-transform-exponentiation-operator": "^6.22.0",
+				"babel-plugin-transform-regenerator": "^6.22.0",
+				"browserslist": "^2.1.2",
+				"invariant": "^2.2.2",
+				"semver": "^5.3.0"
 			}
 		},
 		"babel-preset-flow": {
@@ -1347,17 +1322,17 @@
 			"integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-flow-strip-types": "6.22.0"
+				"babel-plugin-transform-flow-strip-types": "^6.22.0"
 			}
 		},
 		"babel-preset-jest": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.3.tgz",
-			"integrity": "sha512-a+M3LTEXTq3gxv0uBN9Qm6ahUl7a8pj923nFbCUdqFUSsf3YrX8Uc+C3MEwji5Af3LiQjSC7w4ooYewlz8HRTA==",
+			"version": "23.0.1",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.0.1.tgz",
+			"integrity": "sha1-YxzFRcbPAhlDATvK8i9F2H/mIZg=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-jest-hoist": "22.4.3",
-				"babel-plugin-syntax-object-rest-spread": "6.13.0"
+				"babel-plugin-jest-hoist": "^23.0.1",
+				"babel-plugin-syntax-object-rest-spread": "^6.13.0"
 			}
 		},
 		"babel-preset-react": {
@@ -1366,12 +1341,51 @@
 			"integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-jsx": "6.18.0",
-				"babel-plugin-transform-react-display-name": "6.25.0",
-				"babel-plugin-transform-react-jsx": "6.24.1",
-				"babel-plugin-transform-react-jsx-self": "6.22.0",
-				"babel-plugin-transform-react-jsx-source": "6.22.0",
-				"babel-preset-flow": "6.23.0"
+				"babel-plugin-syntax-jsx": "^6.3.13",
+				"babel-plugin-transform-react-display-name": "^6.23.0",
+				"babel-plugin-transform-react-jsx": "^6.24.1",
+				"babel-plugin-transform-react-jsx-self": "^6.22.0",
+				"babel-plugin-transform-react-jsx-source": "^6.22.0",
+				"babel-preset-flow": "^6.23.0"
+			}
+		},
+		"babel-register": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+			"dev": true,
+			"requires": {
+				"babel-core": "^6.26.0",
+				"babel-runtime": "^6.26.0",
+				"core-js": "^2.5.0",
+				"home-or-tmp": "^2.0.0",
+				"lodash": "^4.17.4",
+				"mkdirp": "^0.5.1",
+				"source-map-support": "^0.4.15"
+			},
+			"dependencies": {
+				"babel-runtime": {
+					"version": "6.26.0",
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+					"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+					"dev": true,
+					"requires": {
+						"core-js": "^2.4.0",
+						"regenerator-runtime": "^0.11.0"
+					}
+				},
+				"core-js": {
+					"version": "2.5.7",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+					"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+					"dev": true
+				},
+				"regenerator-runtime": {
+					"version": "0.11.1",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+					"dev": true
+				}
 			}
 		},
 		"babel-runtime": {
@@ -1380,8 +1394,8 @@
 			"integrity": "sha1-M7mOql1IK7AajRqmtDetKwGuxBw=",
 			"dev": true,
 			"requires": {
-				"core-js": "2.4.1",
-				"regenerator-runtime": "0.10.5"
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.10.0"
 			}
 		},
 		"babel-template": {
@@ -1390,11 +1404,11 @@
 			"integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0",
-				"babylon": "6.18.0",
-				"lodash": "4.17.5"
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.25.0",
+				"babel-types": "^6.25.0",
+				"babylon": "^6.17.2",
+				"lodash": "^4.2.0"
 			}
 		},
 		"babel-traverse": {
@@ -1403,15 +1417,15 @@
 			"integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0",
-				"babylon": "6.18.0",
-				"debug": "2.6.8",
-				"globals": "9.18.0",
-				"invariant": "2.2.2",
-				"lodash": "4.17.5"
+				"babel-code-frame": "^6.22.0",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.25.0",
+				"babylon": "^6.17.2",
+				"debug": "^2.2.0",
+				"globals": "^9.0.0",
+				"invariant": "^2.2.0",
+				"lodash": "^4.2.0"
 			}
 		},
 		"babel-types": {
@@ -1420,10 +1434,10 @@
 			"integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"esutils": "2.0.2",
-				"lodash": "4.17.5",
-				"to-fast-properties": "1.0.3"
+				"babel-runtime": "^6.22.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.2.0",
+				"to-fast-properties": "^1.0.1"
 			}
 		},
 		"babylon": {
@@ -1444,13 +1458,13 @@
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
 			"dev": true,
 			"requires": {
-				"cache-base": "1.0.1",
-				"class-utils": "0.3.6",
-				"component-emitter": "1.2.1",
-				"define-property": "1.0.0",
-				"isobject": "3.0.1",
-				"mixin-deep": "1.3.1",
-				"pascalcase": "0.1.1"
+				"cache-base": "^1.0.1",
+				"class-utils": "^0.3.5",
+				"component-emitter": "^1.2.1",
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.1",
+				"mixin-deep": "^1.2.0",
+				"pascalcase": "^0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -1459,7 +1473,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "1.0.2"
+						"is-descriptor": "^1.0.0"
 					}
 				},
 				"isobject": {
@@ -1489,7 +1503,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"tweetnacl": "0.14.5"
+				"tweetnacl": "^0.14.3"
 			}
 		},
 		"big.js": {
@@ -1516,12 +1530,12 @@
 			"integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
 			"dev": true,
 			"requires": {
-				"array-flatten": "2.1.1",
-				"deep-equal": "1.0.1",
-				"dns-equal": "1.0.0",
-				"dns-txt": "2.0.2",
-				"multicast-dns": "6.1.1",
-				"multicast-dns-service-types": "1.1.0"
+				"array-flatten": "^2.1.0",
+				"deep-equal": "^1.0.1",
+				"dns-equal": "^1.0.0",
+				"dns-txt": "^2.0.2",
+				"multicast-dns": "^6.0.1",
+				"multicast-dns-service-types": "^1.1.0"
 			}
 		},
 		"boolbase": {
@@ -1536,7 +1550,7 @@
 			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
 			"dev": true,
 			"requires": {
-				"hoek": "4.2.1"
+				"hoek": "4.x.x"
 			}
 		},
 		"brace-expansion": {
@@ -1545,7 +1559,7 @@
 			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
 			"dev": true,
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -1555,9 +1569,9 @@
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 			"dev": true,
 			"requires": {
-				"expand-range": "1.8.2",
-				"preserve": "0.2.0",
-				"repeat-element": "1.1.2"
+				"expand-range": "^1.8.1",
+				"preserve": "^0.2.0",
+				"repeat-element": "^1.1.2"
 			}
 		},
 		"brorand": {
@@ -1595,11 +1609,11 @@
 			"integrity": "sha1-Xncl297x/Vkw1OurSFZ85FHEigo=",
 			"dev": true,
 			"requires": {
-				"buffer-xor": "1.0.3",
-				"cipher-base": "1.0.4",
-				"create-hash": "1.1.3",
-				"evp_bytestokey": "1.0.0",
-				"inherits": "2.0.3"
+				"buffer-xor": "^1.0.2",
+				"cipher-base": "^1.0.0",
+				"create-hash": "^1.1.0",
+				"evp_bytestokey": "^1.0.0",
+				"inherits": "^2.0.1"
 			}
 		},
 		"browserify-cipher": {
@@ -1608,9 +1622,9 @@
 			"integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
 			"dev": true,
 			"requires": {
-				"browserify-aes": "1.0.6",
-				"browserify-des": "1.0.0",
-				"evp_bytestokey": "1.0.0"
+				"browserify-aes": "^1.0.4",
+				"browserify-des": "^1.0.0",
+				"evp_bytestokey": "^1.0.0"
 			}
 		},
 		"browserify-des": {
@@ -1619,9 +1633,9 @@
 			"integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
 			"dev": true,
 			"requires": {
-				"cipher-base": "1.0.4",
-				"des.js": "1.0.0",
-				"inherits": "2.0.3"
+				"cipher-base": "^1.0.1",
+				"des.js": "^1.0.0",
+				"inherits": "^2.0.1"
 			}
 		},
 		"browserify-rsa": {
@@ -1630,8 +1644,8 @@
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.7",
-				"randombytes": "2.0.5"
+				"bn.js": "^4.1.0",
+				"randombytes": "^2.0.1"
 			}
 		},
 		"browserify-sign": {
@@ -1640,13 +1654,13 @@
 			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.7",
-				"browserify-rsa": "4.0.1",
-				"create-hash": "1.1.3",
-				"create-hmac": "1.1.6",
-				"elliptic": "6.4.0",
-				"inherits": "2.0.3",
-				"parse-asn1": "5.1.0"
+				"bn.js": "^4.1.1",
+				"browserify-rsa": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"create-hmac": "^1.1.2",
+				"elliptic": "^6.0.0",
+				"inherits": "^2.0.1",
+				"parse-asn1": "^5.0.0"
 			}
 		},
 		"browserify-zlib": {
@@ -1655,7 +1669,7 @@
 			"integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
 			"dev": true,
 			"requires": {
-				"pako": "0.2.9"
+				"pako": "~0.2.0"
 			}
 		},
 		"browserslist": {
@@ -1664,8 +1678,8 @@
 			"integrity": "sha512-jDr9Mea+n+FwI+kR0ce7rXCFBoM7hbL80G/th7oPxuNSK4V5J3LPMHB5vykjeI2h7fgSihBbSdoJPmzUC0606Q==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "1.0.30000710",
-				"electron-to-chromium": "1.3.17"
+				"caniuse-lite": "^1.0.30000710",
+				"electron-to-chromium": "^1.3.17"
 			}
 		},
 		"bser": {
@@ -1674,7 +1688,7 @@
 			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
 			"dev": true,
 			"requires": {
-				"node-int64": "0.4.0"
+				"node-int64": "^0.4.0"
 			}
 		},
 		"buffer-from": {
@@ -1725,15 +1739,15 @@
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
 			"dev": true,
 			"requires": {
-				"collection-visit": "1.0.0",
-				"component-emitter": "1.2.1",
-				"get-value": "2.0.6",
-				"has-value": "1.0.0",
-				"isobject": "3.0.1",
-				"set-value": "2.0.0",
-				"to-object-path": "0.3.0",
-				"union-value": "1.0.0",
-				"unset-value": "1.0.0"
+				"collection-visit": "^1.0.0",
+				"component-emitter": "^1.2.1",
+				"get-value": "^2.0.6",
+				"has-value": "^1.0.0",
+				"isobject": "^3.0.1",
+				"set-value": "^2.0.0",
+				"to-object-path": "^0.3.0",
+				"union-value": "^1.0.0",
+				"unset-value": "^1.0.0"
 			},
 			"dependencies": {
 				"isobject": {
@@ -1756,7 +1770,7 @@
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
 			"dev": true,
 			"requires": {
-				"callsites": "0.2.0"
+				"callsites": "^0.2.0"
 			}
 		},
 		"callsites": {
@@ -1777,8 +1791,8 @@
 			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 			"dev": true,
 			"requires": {
-				"camelcase": "2.1.1",
-				"map-obj": "1.0.1"
+				"camelcase": "^2.0.0",
+				"map-obj": "^1.0.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -1794,6 +1808,15 @@
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000710.tgz",
 			"integrity": "sha1-HCSb98amEWHJsQkG462fpbZ2GvE=",
 			"dev": true
+		},
+		"capture-exit": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
+			"integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
+			"dev": true,
+			"requires": {
+				"rsvp": "^3.3.3"
+			}
 		},
 		"capture-stack-trace": {
 			"version": "1.0.0",
@@ -1813,8 +1836,8 @@
 			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
 			"dev": true,
 			"requires": {
-				"align-text": "0.1.4",
-				"lazy-cache": "1.0.4"
+				"align-text": "^0.1.3",
+				"lazy-cache": "^1.0.3"
 			}
 		},
 		"chalk": {
@@ -1823,11 +1846,11 @@
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "2.2.1",
-				"escape-string-regexp": "1.0.5",
-				"has-ansi": "2.0.0",
-				"strip-ansi": "3.0.1",
-				"supports-color": "2.0.0"
+				"ansi-styles": "^2.2.1",
+				"escape-string-regexp": "^1.0.2",
+				"has-ansi": "^2.0.0",
+				"strip-ansi": "^3.0.0",
+				"supports-color": "^2.0.0"
 			}
 		},
 		"chardet": {
@@ -1842,22 +1865,22 @@
 			"integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
 			"dev": true,
 			"requires": {
-				"css-select": "1.2.0",
-				"dom-serializer": "0.1.0",
-				"entities": "1.1.1",
-				"htmlparser2": "3.9.2",
-				"lodash.assignin": "4.2.0",
-				"lodash.bind": "4.2.1",
-				"lodash.defaults": "4.2.0",
-				"lodash.filter": "4.6.0",
-				"lodash.flatten": "4.4.0",
-				"lodash.foreach": "4.5.0",
-				"lodash.map": "4.6.0",
-				"lodash.merge": "4.6.1",
-				"lodash.pick": "4.4.0",
-				"lodash.reduce": "4.6.0",
-				"lodash.reject": "4.6.0",
-				"lodash.some": "4.6.0"
+				"css-select": "~1.2.0",
+				"dom-serializer": "~0.1.0",
+				"entities": "~1.1.1",
+				"htmlparser2": "^3.9.1",
+				"lodash.assignin": "^4.0.9",
+				"lodash.bind": "^4.1.4",
+				"lodash.defaults": "^4.0.1",
+				"lodash.filter": "^4.4.0",
+				"lodash.flatten": "^4.2.0",
+				"lodash.foreach": "^4.3.0",
+				"lodash.map": "^4.4.0",
+				"lodash.merge": "^4.4.0",
+				"lodash.pick": "^4.2.1",
+				"lodash.reduce": "^4.4.0",
+				"lodash.reject": "^4.4.0",
+				"lodash.some": "^4.4.0"
 			},
 			"dependencies": {
 				"css-select": {
@@ -1866,10 +1889,10 @@
 					"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
 					"dev": true,
 					"requires": {
-						"boolbase": "1.0.0",
-						"css-what": "2.1.0",
+						"boolbase": "~1.0.0",
+						"css-what": "2.1",
 						"domutils": "1.5.1",
-						"nth-check": "1.0.1"
+						"nth-check": "~1.0.1"
 					}
 				}
 			}
@@ -1880,15 +1903,15 @@
 			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
 			"dev": true,
 			"requires": {
-				"anymatch": "1.3.2",
-				"async-each": "1.0.1",
-				"fsevents": "1.1.2",
-				"glob-parent": "2.0.0",
-				"inherits": "2.0.3",
-				"is-binary-path": "1.0.1",
-				"is-glob": "2.0.1",
-				"path-is-absolute": "1.0.1",
-				"readdirp": "2.1.0"
+				"anymatch": "^1.3.0",
+				"async-each": "^1.0.0",
+				"fsevents": "^1.0.0",
+				"glob-parent": "^2.0.0",
+				"inherits": "^2.0.1",
+				"is-binary-path": "^1.0.0",
+				"is-glob": "^2.0.0",
+				"path-is-absolute": "^1.0.0",
+				"readdirp": "^2.0.0"
 			}
 		},
 		"ci-info": {
@@ -1903,8 +1926,8 @@
 			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.1"
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"circular-json": {
@@ -1919,10 +1942,10 @@
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
 			"dev": true,
 			"requires": {
-				"arr-union": "3.1.0",
-				"define-property": "0.2.5",
-				"isobject": "3.0.1",
-				"static-extend": "0.1.2"
+				"arr-union": "^3.1.0",
+				"define-property": "^0.2.5",
+				"isobject": "^3.0.0",
+				"static-extend": "^0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -1931,7 +1954,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -1940,7 +1963,7 @@
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -1949,7 +1972,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -1960,7 +1983,7 @@
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -1969,7 +1992,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -1980,9 +2003,9 @@
 					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "0.1.6",
-						"is-data-descriptor": "0.1.4",
-						"kind-of": "5.1.0"
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
 					}
 				},
 				"isobject": {
@@ -2005,7 +2028,7 @@
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 			"dev": true,
 			"requires": {
-				"restore-cursor": "2.0.0"
+				"restore-cursor": "^2.0.0"
 			}
 		},
 		"cli-spinners": {
@@ -2021,7 +2044,7 @@
 			"dev": true,
 			"requires": {
 				"slice-ansi": "0.0.4",
-				"string-width": "1.0.2"
+				"string-width": "^1.0.1"
 			},
 			"dependencies": {
 				"is-fullwidth-code-point": {
@@ -2030,7 +2053,7 @@
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"slice-ansi": {
@@ -2045,9 +2068,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				}
 			}
@@ -2064,8 +2087,8 @@
 			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
 			"dev": true,
 			"requires": {
-				"center-align": "0.1.3",
-				"right-align": "0.1.3",
+				"center-align": "^0.1.1",
+				"right-align": "^0.1.1",
 				"wordwrap": "0.0.2"
 			},
 			"dependencies": {
@@ -2089,8 +2112,8 @@
 			"integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"mkdirp": "0.5.1"
+				"graceful-fs": "^4.1.2",
+				"mkdirp": "~0.5.0"
 			}
 		},
 		"co": {
@@ -2105,7 +2128,7 @@
 			"integrity": "sha512-5wfTTO8E2/ja4jFSxePXlG5nRu5bBtL/r1HCIpJW/lzT6yDtKl0u0Z4o/Vpz32IpKmBn7HerheEZQgA9N2DarQ==",
 			"dev": true,
 			"requires": {
-				"q": "1.5.1"
+				"q": "^1.1.2"
 			}
 		},
 		"code-point-at": {
@@ -2120,8 +2143,8 @@
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
 			"dev": true,
 			"requires": {
-				"map-visit": "1.0.0",
-				"object-visit": "1.0.1"
+				"map-visit": "^1.0.0",
+				"object-visit": "^1.0.0"
 			}
 		},
 		"color-convert": {
@@ -2130,7 +2153,7 @@
 			"integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
 			"dev": true,
 			"requires": {
-				"color-name": "1.1.3"
+				"color-name": "^1.1.1"
 			}
 		},
 		"color-name": {
@@ -2151,8 +2174,8 @@
 			"integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
 			"dev": true,
 			"requires": {
-				"strip-ansi": "3.0.1",
-				"wcwidth": "1.0.1"
+				"strip-ansi": "^3.0.0",
+				"wcwidth": "^1.0.0"
 			}
 		},
 		"combined-stream": {
@@ -2161,7 +2184,7 @@
 			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
 			"dev": true,
 			"requires": {
-				"delayed-stream": "1.0.0"
+				"delayed-stream": "~1.0.0"
 			}
 		},
 		"command-join": {
@@ -2188,14 +2211,14 @@
 			"integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
 			"dev": true,
 			"requires": {
-				"array-ify": "1.0.0",
-				"dot-prop": "3.0.0"
+				"array-ify": "^1.0.0",
+				"dot-prop": "^3.0.0"
 			}
 		},
 		"compare-versions": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.1.0.tgz",
-			"integrity": "sha512-4hAxDSBypT/yp2ySFD346So6Ragw5xmBn/e/agIGl3bZr6DLUqnoRZPusxKrXdYRZpgexO9daejmIenlq/wrIQ==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.2.1.tgz",
+			"integrity": "sha512-2y2nHcopMG/NAyk6vWXlLs86XeM9sik4jmx1tKIgzMi9/RQ2eo758RGpxQO3ErihHmg0RlQITPqgz73y6s7quA==",
 			"dev": true
 		},
 		"component-emitter": {
@@ -2210,7 +2233,7 @@
 			"integrity": "sha1-FnGKdd4oPtjmBAQWJaIGRYZ5fYo=",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.29.0"
+				"mime-db": ">= 1.29.0 < 2"
 			}
 		},
 		"compression": {
@@ -2219,13 +2242,13 @@
 			"integrity": "sha1-AwyfGY8WQ6BX13anOOki2kNzAS0=",
 			"dev": true,
 			"requires": {
-				"accepts": "1.3.3",
+				"accepts": "~1.3.3",
 				"bytes": "2.5.0",
-				"compressible": "2.0.11",
+				"compressible": "~2.0.10",
 				"debug": "2.6.8",
-				"on-headers": "1.0.1",
+				"on-headers": "~1.0.1",
 				"safe-buffer": "5.1.1",
-				"vary": "1.1.1"
+				"vary": "~1.1.1"
 			}
 		},
 		"concat-map": {
@@ -2240,10 +2263,10 @@
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 			"dev": true,
 			"requires": {
-				"buffer-from": "1.0.0",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3",
-				"typedarray": "0.0.6"
+				"buffer-from": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.2.2",
+				"typedarray": "^0.0.6"
 			}
 		},
 		"concat-with-sourcemaps": {
@@ -2252,7 +2275,7 @@
 			"integrity": "sha512-YtnS0VEY+e2Khzsey/6mra9EoM6h/5gxaC0e3mcHpA5yfDxafhygytNmcJWodvUgyXzSiL5MSkPO6bQGgfliHw==",
 			"dev": true,
 			"requires": {
-				"source-map": "0.6.1"
+				"source-map": "^0.6.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -2275,7 +2298,7 @@
 			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
 			"dev": true,
 			"requires": {
-				"date-now": "0.1.4"
+				"date-now": "^0.1.4"
 			}
 		},
 		"console-control-strings": {
@@ -2314,17 +2337,17 @@
 			"integrity": "sha512-CvFAZ9E/9F8abCqymsV9uDtYSN6XLoEQhFVHOcicCxnnhneLHUio0Jad8KJ+7fUUoVVL26LpIl5zjvi1SyJrww==",
 			"dev": true,
 			"requires": {
-				"conventional-changelog-angular": "1.6.6",
-				"conventional-changelog-atom": "0.2.7",
-				"conventional-changelog-codemirror": "0.3.7",
-				"conventional-changelog-core": "2.0.9",
-				"conventional-changelog-ember": "0.3.10",
-				"conventional-changelog-eslint": "1.0.8",
-				"conventional-changelog-express": "0.3.6",
-				"conventional-changelog-jquery": "0.1.0",
-				"conventional-changelog-jscs": "0.1.0",
-				"conventional-changelog-jshint": "0.3.7",
-				"conventional-changelog-preset-loader": "1.1.8"
+				"conventional-changelog-angular": "^1.6.6",
+				"conventional-changelog-atom": "^0.2.7",
+				"conventional-changelog-codemirror": "^0.3.7",
+				"conventional-changelog-core": "^2.0.9",
+				"conventional-changelog-ember": "^0.3.10",
+				"conventional-changelog-eslint": "^1.0.8",
+				"conventional-changelog-express": "^0.3.6",
+				"conventional-changelog-jquery": "^0.1.0",
+				"conventional-changelog-jscs": "^0.1.0",
+				"conventional-changelog-jshint": "^0.3.7",
+				"conventional-changelog-preset-loader": "^1.1.8"
 			}
 		},
 		"conventional-changelog-angular": {
@@ -2333,8 +2356,8 @@
 			"integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
 			"dev": true,
 			"requires": {
-				"compare-func": "1.3.2",
-				"q": "1.5.1"
+				"compare-func": "^1.3.1",
+				"q": "^1.5.1"
 			}
 		},
 		"conventional-changelog-atom": {
@@ -2343,7 +2366,7 @@
 			"integrity": "sha512-h4e/hv4FtjoL5ZpAFyY1eSePFHE/BiaBNflHMY6o2R6xUEc3BubwNpuqIaXmuAG/7H+JMXoHF4HfS/wYT1VowQ==",
 			"dev": true,
 			"requires": {
-				"q": "1.5.1"
+				"q": "^1.5.1"
 			}
 		},
 		"conventional-changelog-cli": {
@@ -2352,11 +2375,11 @@
 			"integrity": "sha512-tw5NsliHuYkmKkbOfXeQb0O8v25hUm2FGeWkSDT+xhLq3O2xFFOpS3wKe+lc8FJFzJgZJ8F1F8AEDOkXtO/42g==",
 			"dev": true,
 			"requires": {
-				"add-stream": "1.0.0",
-				"conventional-changelog": "1.1.22",
-				"lodash": "4.17.5",
-				"meow": "4.0.0",
-				"tempfile": "1.1.1"
+				"add-stream": "^1.0.0",
+				"conventional-changelog": "^1.1.22",
+				"lodash": "^4.2.1",
+				"meow": "^4.0.0",
+				"tempfile": "^1.1.1"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -2371,9 +2394,9 @@
 					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0",
-						"map-obj": "2.0.0",
-						"quick-lru": "1.1.0"
+						"camelcase": "^4.1.0",
+						"map-obj": "^2.0.0",
+						"quick-lru": "^1.0.0"
 					}
 				},
 				"indent-string": {
@@ -2388,10 +2411,10 @@
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "4.0.0",
-						"pify": "3.0.0",
-						"strip-bom": "3.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
 					}
 				},
 				"map-obj": {
@@ -2406,15 +2429,15 @@
 					"integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
 					"dev": true,
 					"requires": {
-						"camelcase-keys": "4.2.0",
-						"decamelize-keys": "1.1.0",
-						"loud-rejection": "1.6.0",
-						"minimist": "1.2.0",
-						"minimist-options": "3.0.2",
-						"normalize-package-data": "2.4.0",
-						"read-pkg-up": "3.0.0",
-						"redent": "2.0.0",
-						"trim-newlines": "2.0.0"
+						"camelcase-keys": "^4.0.0",
+						"decamelize-keys": "^1.0.0",
+						"loud-rejection": "^1.0.0",
+						"minimist": "^1.1.3",
+						"minimist-options": "^3.0.1",
+						"normalize-package-data": "^2.3.4",
+						"read-pkg-up": "^3.0.0",
+						"redent": "^2.0.0",
+						"trim-newlines": "^2.0.0"
 					}
 				},
 				"minimist": {
@@ -2429,8 +2452,8 @@
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 					"dev": true,
 					"requires": {
-						"error-ex": "1.3.1",
-						"json-parse-better-errors": "1.0.1"
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
 					}
 				},
 				"path-type": {
@@ -2439,7 +2462,7 @@
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 					"dev": true,
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"read-pkg": {
@@ -2448,9 +2471,9 @@
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "4.0.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "3.0.0"
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -2459,8 +2482,8 @@
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 					"dev": true,
 					"requires": {
-						"find-up": "2.1.0",
-						"read-pkg": "3.0.0"
+						"find-up": "^2.0.0",
+						"read-pkg": "^3.0.0"
 					}
 				},
 				"redent": {
@@ -2469,8 +2492,8 @@
 					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
 					"dev": true,
 					"requires": {
-						"indent-string": "3.2.0",
-						"strip-indent": "2.0.0"
+						"indent-string": "^3.0.0",
+						"strip-indent": "^2.0.0"
 					}
 				},
 				"strip-bom": {
@@ -2493,7 +2516,7 @@
 			"integrity": "sha512-N/hiEBFtiYRwo9hWFuk1akhmniXxVduuMN6BSgB2kFxo4sQIJQjO0JaX88RLoneXuq1CKR3Z3Lc+DTLnqg7atQ==",
 			"dev": true,
 			"requires": {
-				"q": "1.5.1"
+				"q": "^1.5.1"
 			}
 		},
 		"conventional-changelog-core": {
@@ -2502,19 +2525,19 @@
 			"integrity": "sha512-OWbjJcZe+s+RxVQe2pe2oO1YNpWTgks6Pof99xPYxMtTRg7RnWn8E4hCIMqHtp/Q/FK7fD8Hb1i3ISwTQZWGFA==",
 			"dev": true,
 			"requires": {
-				"conventional-changelog-writer": "3.0.8",
-				"conventional-commits-parser": "2.1.7",
-				"dateformat": "3.0.3",
-				"get-pkg-repo": "1.4.0",
-				"git-raw-commits": "1.3.6",
-				"git-remote-origin-url": "2.0.0",
-				"git-semver-tags": "1.3.6",
-				"lodash": "4.17.5",
-				"normalize-package-data": "2.4.0",
-				"q": "1.5.1",
-				"read-pkg": "1.1.0",
-				"read-pkg-up": "1.0.1",
-				"through2": "2.0.3"
+				"conventional-changelog-writer": "^3.0.8",
+				"conventional-commits-parser": "^2.1.7",
+				"dateformat": "^3.0.0",
+				"get-pkg-repo": "^1.0.0",
+				"git-raw-commits": "^1.3.6",
+				"git-remote-origin-url": "^2.0.0",
+				"git-semver-tags": "^1.3.6",
+				"lodash": "^4.2.1",
+				"normalize-package-data": "^2.3.5",
+				"q": "^1.5.1",
+				"read-pkg": "^1.1.0",
+				"read-pkg-up": "^1.0.1",
+				"through2": "^2.0.0"
 			}
 		},
 		"conventional-changelog-ember": {
@@ -2523,7 +2546,7 @@
 			"integrity": "sha512-EN9E3BBNXmSYyduTXPB2Vxf3XCKHycm0BrXctaVKzcOnZnj2IkcJVsK+ipMlW+Br0PeomMRCRu76SQgIE+Hn1w==",
 			"dev": true,
 			"requires": {
-				"q": "1.5.1"
+				"q": "^1.5.1"
 			}
 		},
 		"conventional-changelog-eslint": {
@@ -2532,7 +2555,7 @@
 			"integrity": "sha512-RhjwYJEympR4HtDgASEyqbVU0FRexlCcyuGbC+SaaOt3NvUwVvn4aRNu7+vzZotPZ/P7tqlCBZpN2OnT9WgncA==",
 			"dev": true,
 			"requires": {
-				"q": "1.5.1"
+				"q": "^1.5.1"
 			}
 		},
 		"conventional-changelog-express": {
@@ -2541,7 +2564,7 @@
 			"integrity": "sha512-3iWVtBJZ9RnRnZveNDzOD8QRn6g6vUif0qVTWWyi5nUIAbuN1FfPVyKdAlJJfp5Im+dE8Kiy/d2SpaX/0X678Q==",
 			"dev": true,
 			"requires": {
-				"q": "1.5.1"
+				"q": "^1.5.1"
 			}
 		},
 		"conventional-changelog-jquery": {
@@ -2550,7 +2573,7 @@
 			"integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
 			"dev": true,
 			"requires": {
-				"q": "1.5.1"
+				"q": "^1.4.1"
 			}
 		},
 		"conventional-changelog-jscs": {
@@ -2559,7 +2582,7 @@
 			"integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
 			"dev": true,
 			"requires": {
-				"q": "1.5.1"
+				"q": "^1.4.1"
 			}
 		},
 		"conventional-changelog-jshint": {
@@ -2568,8 +2591,8 @@
 			"integrity": "sha512-03S2GPwtPolFAjfrhea8QrNjfcNifoeXmYHS4gFDQETdSGW/Y3gqN0ucl8Y7cyJDOiSNmIDi3BELIID12pjSQA==",
 			"dev": true,
 			"requires": {
-				"compare-func": "1.3.2",
-				"q": "1.5.1"
+				"compare-func": "^1.3.1",
+				"q": "^1.5.1"
 			}
 		},
 		"conventional-changelog-preset-loader": {
@@ -2584,16 +2607,16 @@
 			"integrity": "sha512-8kGEd4+UKJuNMNtOp5xSSgeH5E6ysJARDUjeq03nomjhQIpqiXj4gP61HhgdfEbk+W0RdHrz3tDf0fmYgaNMpA==",
 			"dev": true,
 			"requires": {
-				"compare-func": "1.3.2",
-				"conventional-commits-filter": "1.1.6",
-				"dateformat": "3.0.3",
-				"handlebars": "4.0.10",
-				"json-stringify-safe": "5.0.1",
-				"lodash": "4.17.5",
-				"meow": "4.0.0",
-				"semver": "5.5.0",
-				"split": "1.0.1",
-				"through2": "2.0.3"
+				"compare-func": "^1.3.1",
+				"conventional-commits-filter": "^1.1.6",
+				"dateformat": "^3.0.0",
+				"handlebars": "^4.0.2",
+				"json-stringify-safe": "^5.0.1",
+				"lodash": "^4.2.1",
+				"meow": "^4.0.0",
+				"semver": "^5.5.0",
+				"split": "^1.0.0",
+				"through2": "^2.0.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -2608,9 +2631,9 @@
 					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0",
-						"map-obj": "2.0.0",
-						"quick-lru": "1.1.0"
+						"camelcase": "^4.1.0",
+						"map-obj": "^2.0.0",
+						"quick-lru": "^1.0.0"
 					}
 				},
 				"indent-string": {
@@ -2625,10 +2648,10 @@
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "4.0.0",
-						"pify": "3.0.0",
-						"strip-bom": "3.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
 					}
 				},
 				"map-obj": {
@@ -2643,15 +2666,15 @@
 					"integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
 					"dev": true,
 					"requires": {
-						"camelcase-keys": "4.2.0",
-						"decamelize-keys": "1.1.0",
-						"loud-rejection": "1.6.0",
-						"minimist": "1.2.0",
-						"minimist-options": "3.0.2",
-						"normalize-package-data": "2.4.0",
-						"read-pkg-up": "3.0.0",
-						"redent": "2.0.0",
-						"trim-newlines": "2.0.0"
+						"camelcase-keys": "^4.0.0",
+						"decamelize-keys": "^1.0.0",
+						"loud-rejection": "^1.0.0",
+						"minimist": "^1.1.3",
+						"minimist-options": "^3.0.1",
+						"normalize-package-data": "^2.3.4",
+						"read-pkg-up": "^3.0.0",
+						"redent": "^2.0.0",
+						"trim-newlines": "^2.0.0"
 					}
 				},
 				"minimist": {
@@ -2666,8 +2689,8 @@
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 					"dev": true,
 					"requires": {
-						"error-ex": "1.3.1",
-						"json-parse-better-errors": "1.0.1"
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
 					}
 				},
 				"path-type": {
@@ -2676,7 +2699,7 @@
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 					"dev": true,
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"read-pkg": {
@@ -2685,9 +2708,9 @@
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "4.0.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "3.0.0"
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -2696,8 +2719,8 @@
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 					"dev": true,
 					"requires": {
-						"find-up": "2.1.0",
-						"read-pkg": "3.0.0"
+						"find-up": "^2.0.0",
+						"read-pkg": "^3.0.0"
 					}
 				},
 				"redent": {
@@ -2706,8 +2729,8 @@
 					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
 					"dev": true,
 					"requires": {
-						"indent-string": "3.2.0",
-						"strip-indent": "2.0.0"
+						"indent-string": "^3.0.0",
+						"strip-indent": "^2.0.0"
 					}
 				},
 				"semver": {
@@ -2736,8 +2759,8 @@
 			"integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
 			"dev": true,
 			"requires": {
-				"is-subset": "0.1.1",
-				"modify-values": "1.0.1"
+				"is-subset": "^0.1.1",
+				"modify-values": "^1.0.0"
 			}
 		},
 		"conventional-commits-parser": {
@@ -2746,13 +2769,13 @@
 			"integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
 			"dev": true,
 			"requires": {
-				"JSONStream": "1.3.2",
-				"is-text-path": "1.0.1",
-				"lodash": "4.17.5",
-				"meow": "4.0.0",
-				"split2": "2.2.0",
-				"through2": "2.0.3",
-				"trim-off-newlines": "1.0.1"
+				"JSONStream": "^1.0.4",
+				"is-text-path": "^1.0.0",
+				"lodash": "^4.2.1",
+				"meow": "^4.0.0",
+				"split2": "^2.0.0",
+				"through2": "^2.0.0",
+				"trim-off-newlines": "^1.0.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -2767,9 +2790,9 @@
 					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0",
-						"map-obj": "2.0.0",
-						"quick-lru": "1.1.0"
+						"camelcase": "^4.1.0",
+						"map-obj": "^2.0.0",
+						"quick-lru": "^1.0.0"
 					}
 				},
 				"indent-string": {
@@ -2784,10 +2807,10 @@
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "4.0.0",
-						"pify": "3.0.0",
-						"strip-bom": "3.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
 					}
 				},
 				"map-obj": {
@@ -2802,15 +2825,15 @@
 					"integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
 					"dev": true,
 					"requires": {
-						"camelcase-keys": "4.2.0",
-						"decamelize-keys": "1.1.0",
-						"loud-rejection": "1.6.0",
-						"minimist": "1.2.0",
-						"minimist-options": "3.0.2",
-						"normalize-package-data": "2.4.0",
-						"read-pkg-up": "3.0.0",
-						"redent": "2.0.0",
-						"trim-newlines": "2.0.0"
+						"camelcase-keys": "^4.0.0",
+						"decamelize-keys": "^1.0.0",
+						"loud-rejection": "^1.0.0",
+						"minimist": "^1.1.3",
+						"minimist-options": "^3.0.1",
+						"normalize-package-data": "^2.3.4",
+						"read-pkg-up": "^3.0.0",
+						"redent": "^2.0.0",
+						"trim-newlines": "^2.0.0"
 					}
 				},
 				"minimist": {
@@ -2825,8 +2848,8 @@
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 					"dev": true,
 					"requires": {
-						"error-ex": "1.3.1",
-						"json-parse-better-errors": "1.0.1"
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
 					}
 				},
 				"path-type": {
@@ -2835,7 +2858,7 @@
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 					"dev": true,
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"read-pkg": {
@@ -2844,9 +2867,9 @@
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "4.0.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "3.0.0"
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -2855,8 +2878,8 @@
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 					"dev": true,
 					"requires": {
-						"find-up": "2.1.0",
-						"read-pkg": "3.0.0"
+						"find-up": "^2.0.0",
+						"read-pkg": "^3.0.0"
 					}
 				},
 				"redent": {
@@ -2865,8 +2888,8 @@
 					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
 					"dev": true,
 					"requires": {
-						"indent-string": "3.2.0",
-						"strip-indent": "2.0.0"
+						"indent-string": "^3.0.0",
+						"strip-indent": "^2.0.0"
 					}
 				},
 				"strip-bom": {
@@ -2889,19 +2912,19 @@
 			"integrity": "sha512-oJjG6DkRgtnr/t/VrPdzmf4XZv8c4xKVJrVT4zrSHd92KEL+EYxSbYoKq8lQ7U5yLMw7130wrcQTLRjM/T+d4w==",
 			"dev": true,
 			"requires": {
-				"concat-stream": "1.6.2",
-				"conventional-commits-filter": "1.1.6",
-				"conventional-commits-parser": "2.1.7",
-				"git-raw-commits": "1.3.6",
-				"git-semver-tags": "1.3.6",
-				"meow": "3.7.0",
-				"object-assign": "4.1.1"
+				"concat-stream": "^1.4.10",
+				"conventional-commits-filter": "^1.1.1",
+				"conventional-commits-parser": "^2.1.1",
+				"git-raw-commits": "^1.3.0",
+				"git-semver-tags": "^1.3.0",
+				"meow": "^3.3.0",
+				"object-assign": "^4.0.1"
 			}
 		},
 		"convert-source-map": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-			"integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
 			"dev": true
 		},
 		"cookie": {
@@ -2940,10 +2963,10 @@
 			"integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
 			"dev": true,
 			"requires": {
-				"is-directory": "0.3.1",
-				"js-yaml": "3.9.1",
-				"parse-json": "4.0.0",
-				"require-from-string": "2.0.2"
+				"is-directory": "^0.3.1",
+				"js-yaml": "^3.9.0",
+				"parse-json": "^4.0.0",
+				"require-from-string": "^2.0.1"
 			},
 			"dependencies": {
 				"parse-json": {
@@ -2952,8 +2975,8 @@
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 					"dev": true,
 					"requires": {
-						"error-ex": "1.3.1",
-						"json-parse-better-errors": "1.0.1"
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
 					}
 				}
 			}
@@ -2964,11 +2987,11 @@
 			"integrity": "sha1-vHAP0wyjLSTUbH+wK5kuQ1/FqXg=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"make-dir": "1.2.0",
-				"nested-error-stacks": "2.0.0",
-				"pify": "3.0.0",
-				"safe-buffer": "5.1.1"
+				"graceful-fs": "^4.1.2",
+				"make-dir": "^1.0.0",
+				"nested-error-stacks": "^2.0.0",
+				"pify": "^3.0.0",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"create-ecdh": {
@@ -2977,8 +3000,8 @@
 			"integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.7",
-				"elliptic": "6.4.0"
+				"bn.js": "^4.1.0",
+				"elliptic": "^6.0.0"
 			}
 		},
 		"create-error-class": {
@@ -2987,7 +3010,7 @@
 			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
 			"dev": true,
 			"requires": {
-				"capture-stack-trace": "1.0.0"
+				"capture-stack-trace": "^1.0.0"
 			}
 		},
 		"create-hash": {
@@ -2996,10 +3019,10 @@
 			"integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
 			"dev": true,
 			"requires": {
-				"cipher-base": "1.0.4",
-				"inherits": "2.0.3",
-				"ripemd160": "2.0.1",
-				"sha.js": "2.4.8"
+				"cipher-base": "^1.0.1",
+				"inherits": "^2.0.1",
+				"ripemd160": "^2.0.0",
+				"sha.js": "^2.4.0"
 			}
 		},
 		"create-hmac": {
@@ -3008,12 +3031,12 @@
 			"integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
 			"dev": true,
 			"requires": {
-				"cipher-base": "1.0.4",
-				"create-hash": "1.1.3",
-				"inherits": "2.0.3",
-				"ripemd160": "2.0.1",
-				"safe-buffer": "5.1.1",
-				"sha.js": "2.4.8"
+				"cipher-base": "^1.0.3",
+				"create-hash": "^1.1.0",
+				"inherits": "^2.0.1",
+				"ripemd160": "^2.0.0",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
 			}
 		},
 		"cross-spawn": {
@@ -3022,9 +3045,9 @@
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"dev": true,
 			"requires": {
-				"lru-cache": "4.1.1",
-				"shebang-command": "1.2.0",
-				"which": "1.3.0"
+				"lru-cache": "^4.0.1",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
 			}
 		},
 		"cryptiles": {
@@ -3033,7 +3056,7 @@
 			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
 			"dev": true,
 			"requires": {
-				"boom": "5.2.0"
+				"boom": "5.x.x"
 			},
 			"dependencies": {
 				"boom": {
@@ -3042,7 +3065,7 @@
 					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
 					"dev": true,
 					"requires": {
-						"hoek": "4.2.1"
+						"hoek": "4.x.x"
 					}
 				}
 			}
@@ -3053,16 +3076,16 @@
 			"integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
 			"dev": true,
 			"requires": {
-				"browserify-cipher": "1.0.0",
-				"browserify-sign": "4.0.4",
-				"create-ecdh": "4.0.0",
-				"create-hash": "1.1.3",
-				"create-hmac": "1.1.6",
-				"diffie-hellman": "5.0.2",
-				"inherits": "2.0.3",
-				"pbkdf2": "3.0.13",
-				"public-encrypt": "4.0.0",
-				"randombytes": "2.0.5"
+				"browserify-cipher": "^1.0.0",
+				"browserify-sign": "^4.0.0",
+				"create-ecdh": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"create-hmac": "^1.1.0",
+				"diffie-hellman": "^5.0.0",
+				"inherits": "^2.0.1",
+				"pbkdf2": "^3.0.3",
+				"public-encrypt": "^4.0.0",
+				"randombytes": "^2.0.0"
 			}
 		},
 		"css-select": {
@@ -3071,10 +3094,10 @@
 			"integrity": "sha1-b5MZaqrnN2ZuoQNqjLFKj8t6kjE=",
 			"dev": true,
 			"requires": {
-				"boolbase": "1.0.0",
-				"css-what": "2.1.0",
+				"boolbase": "^1.0.0",
+				"css-what": "2.1",
 				"domutils": "1.5.1",
-				"nth-check": "1.0.1"
+				"nth-check": "^1.0.1"
 			}
 		},
 		"css-select-base-adapter": {
@@ -3089,8 +3112,8 @@
 			"integrity": "sha512-BAYp9FyN4jLXjfvRpTDchBllDptqlK9I7OsagXCG9Am5C+5jc8eRZHgqb9x500W2OKS14MMlpQc/nmh/aA7TEQ==",
 			"dev": true,
 			"requires": {
-				"mdn-data": "1.1.1",
-				"source-map": "0.5.6"
+				"mdn-data": "^1.0.0",
+				"source-map": "^0.5.3"
 			}
 		},
 		"css-url-regex": {
@@ -3126,7 +3149,7 @@
 			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
 			"dev": true,
 			"requires": {
-				"cssom": "0.3.2"
+				"cssom": "0.3.x"
 			}
 		},
 		"currently-unhandled": {
@@ -3135,7 +3158,7 @@
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
 			"dev": true,
 			"requires": {
-				"array-find-index": "1.0.2"
+				"array-find-index": "^1.0.1"
 			}
 		},
 		"d": {
@@ -3144,7 +3167,7 @@
 			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
 			"dev": true,
 			"requires": {
-				"es5-ext": "0.10.26"
+				"es5-ext": "^0.10.9"
 			}
 		},
 		"dargs": {
@@ -3153,7 +3176,7 @@
 			"integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
 		},
 		"dashdash": {
@@ -3162,7 +3185,7 @@
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			},
 			"dependencies": {
 				"assert-plus": {
@@ -3212,8 +3235,8 @@
 			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
 			"dev": true,
 			"requires": {
-				"decamelize": "1.2.0",
-				"map-obj": "1.0.1"
+				"decamelize": "^1.1.0",
+				"map-obj": "^1.0.0"
 			}
 		},
 		"decode-uri-component": {
@@ -3252,7 +3275,7 @@
 			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
 			"dev": true,
 			"requires": {
-				"strip-bom": "2.0.0"
+				"strip-bom": "^2.0.0"
 			}
 		},
 		"defaults": {
@@ -3261,7 +3284,7 @@
 			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
 			"dev": true,
 			"requires": {
-				"clone": "1.0.4"
+				"clone": "^1.0.2"
 			}
 		},
 		"define-properties": {
@@ -3270,8 +3293,8 @@
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
 			"dev": true,
 			"requires": {
-				"foreach": "2.0.5",
-				"object-keys": "1.0.11"
+				"foreach": "^2.0.5",
+				"object-keys": "^1.0.8"
 			}
 		},
 		"define-property": {
@@ -3280,8 +3303,8 @@
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
 			"dev": true,
 			"requires": {
-				"is-descriptor": "1.0.2",
-				"isobject": "3.0.1"
+				"is-descriptor": "^1.0.2",
+				"isobject": "^3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -3298,12 +3321,12 @@
 			"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
 			"dev": true,
 			"requires": {
-				"globby": "6.1.0",
-				"is-path-cwd": "1.0.0",
-				"is-path-in-cwd": "1.0.0",
-				"p-map": "1.1.1",
-				"pify": "3.0.0",
-				"rimraf": "2.6.1"
+				"globby": "^6.1.0",
+				"is-path-cwd": "^1.0.0",
+				"is-path-in-cwd": "^1.0.0",
+				"p-map": "^1.1.1",
+				"pify": "^3.0.0",
+				"rimraf": "^2.2.8"
 			},
 			"dependencies": {
 				"pify": {
@@ -3338,8 +3361,8 @@
 			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0"
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0"
 			}
 		},
 		"destroy": {
@@ -3354,7 +3377,7 @@
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
 			"dev": true,
 			"requires": {
-				"repeating": "2.0.1"
+				"repeating": "^2.0.0"
 			}
 		},
 		"detect-newline": {
@@ -3381,9 +3404,9 @@
 			"integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.7",
-				"miller-rabin": "4.0.0",
-				"randombytes": "2.0.5"
+				"bn.js": "^4.1.0",
+				"miller-rabin": "^4.0.0",
+				"randombytes": "^2.0.0"
 			}
 		},
 		"dir-glob": {
@@ -3392,8 +3415,8 @@
 			"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
-				"path-type": "3.0.0"
+				"arrify": "^1.0.1",
+				"path-type": "^3.0.0"
 			},
 			"dependencies": {
 				"path-type": {
@@ -3402,7 +3425,7 @@
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 					"dev": true,
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				}
 			}
@@ -3419,8 +3442,8 @@
 			"integrity": "sha1-I2nUUDivBF84mOb6VoYq7T9AKWw=",
 			"dev": true,
 			"requires": {
-				"ip": "1.1.5",
-				"safe-buffer": "5.1.1"
+				"ip": "^1.1.0",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"dns-txt": {
@@ -3429,7 +3452,7 @@
 			"integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
 			"dev": true,
 			"requires": {
-				"buffer-indexof": "1.1.0"
+				"buffer-indexof": "^1.0.0"
 			}
 		},
 		"doctrine": {
@@ -3438,7 +3461,7 @@
 			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
 			"dev": true,
 			"requires": {
-				"esutils": "2.0.2"
+				"esutils": "^2.0.2"
 			}
 		},
 		"dom-serializer": {
@@ -3447,8 +3470,8 @@
 			"integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
 			"dev": true,
 			"requires": {
-				"domelementtype": "1.1.3",
-				"entities": "1.1.1"
+				"domelementtype": "~1.1.1",
+				"entities": "~1.1.1"
 			},
 			"dependencies": {
 				"domelementtype": {
@@ -3483,7 +3506,7 @@
 			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
 			"dev": true,
 			"requires": {
-				"webidl-conversions": "4.0.2"
+				"webidl-conversions": "^4.0.2"
 			},
 			"dependencies": {
 				"webidl-conversions": {
@@ -3500,7 +3523,7 @@
 			"integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
 			"dev": true,
 			"requires": {
-				"domelementtype": "1.3.0"
+				"domelementtype": "1"
 			}
 		},
 		"domutils": {
@@ -3509,8 +3532,8 @@
 			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
 			"dev": true,
 			"requires": {
-				"dom-serializer": "0.1.0",
-				"domelementtype": "1.3.0"
+				"dom-serializer": "0",
+				"domelementtype": "1"
 			}
 		},
 		"dot-prop": {
@@ -3519,7 +3542,7 @@
 			"integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
 			"dev": true,
 			"requires": {
-				"is-obj": "1.0.1"
+				"is-obj": "^1.0.0"
 			}
 		},
 		"duplexer": {
@@ -3541,7 +3564,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"jsbn": "0.1.1"
+				"jsbn": "~0.1.0"
 			}
 		},
 		"ee-first": {
@@ -3568,13 +3591,13 @@
 			"integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.7",
-				"brorand": "1.1.0",
-				"hash.js": "1.1.3",
-				"hmac-drbg": "1.0.1",
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0",
-				"minimalistic-crypto-utils": "1.0.1"
+				"bn.js": "^4.4.0",
+				"brorand": "^1.0.1",
+				"hash.js": "^1.0.0",
+				"hmac-drbg": "^1.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.0"
 			}
 		},
 		"emojis-list": {
@@ -3595,10 +3618,10 @@
 			"integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"memory-fs": "0.4.1",
-				"object-assign": "4.1.1",
-				"tapable": "0.2.8"
+				"graceful-fs": "^4.1.2",
+				"memory-fs": "^0.4.0",
+				"object-assign": "^4.0.1",
+				"tapable": "^0.2.7"
 			}
 		},
 		"entities": {
@@ -3613,7 +3636,7 @@
 			"integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
 			"dev": true,
 			"requires": {
-				"prr": "0.0.0"
+				"prr": "~0.0.0"
 			}
 		},
 		"error-ex": {
@@ -3622,7 +3645,7 @@
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
 			"dev": true,
 			"requires": {
-				"is-arrayish": "0.2.1"
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"es-abstract": {
@@ -3631,11 +3654,11 @@
 			"integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
 			"dev": true,
 			"requires": {
-				"es-to-primitive": "1.1.1",
-				"function-bind": "1.1.1",
-				"has": "1.0.1",
-				"is-callable": "1.1.3",
-				"is-regex": "1.0.4"
+				"es-to-primitive": "^1.1.1",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.1",
+				"is-callable": "^1.1.3",
+				"is-regex": "^1.0.4"
 			}
 		},
 		"es-to-primitive": {
@@ -3644,9 +3667,9 @@
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
 			"dev": true,
 			"requires": {
-				"is-callable": "1.1.3",
-				"is-date-object": "1.0.1",
-				"is-symbol": "1.0.1"
+				"is-callable": "^1.1.1",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.1"
 			}
 		},
 		"es5-ext": {
@@ -3655,8 +3678,8 @@
 			"integrity": "sha1-UbISilMbcMT2dkCTpzy+u4IYY3I=",
 			"dev": true,
 			"requires": {
-				"es6-iterator": "2.0.1",
-				"es6-symbol": "3.1.1"
+				"es6-iterator": "2",
+				"es6-symbol": "~3.1"
 			}
 		},
 		"es6-iterator": {
@@ -3665,9 +3688,9 @@
 			"integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
 			"dev": true,
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.26",
-				"es6-symbol": "3.1.1"
+				"d": "1",
+				"es5-ext": "^0.10.14",
+				"es6-symbol": "^3.1"
 			}
 		},
 		"es6-map": {
@@ -3676,12 +3699,12 @@
 			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
 			"dev": true,
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.26",
-				"es6-iterator": "2.0.1",
-				"es6-set": "0.1.5",
-				"es6-symbol": "3.1.1",
-				"event-emitter": "0.3.5"
+				"d": "1",
+				"es5-ext": "~0.10.14",
+				"es6-iterator": "~2.0.1",
+				"es6-set": "~0.1.5",
+				"es6-symbol": "~3.1.1",
+				"event-emitter": "~0.3.5"
 			}
 		},
 		"es6-set": {
@@ -3690,11 +3713,11 @@
 			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
 			"dev": true,
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.26",
-				"es6-iterator": "2.0.1",
+				"d": "1",
+				"es5-ext": "~0.10.14",
+				"es6-iterator": "~2.0.1",
 				"es6-symbol": "3.1.1",
-				"event-emitter": "0.3.5"
+				"event-emitter": "~0.3.5"
 			}
 		},
 		"es6-symbol": {
@@ -3703,8 +3726,8 @@
 			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
 			"dev": true,
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.26"
+				"d": "1",
+				"es5-ext": "~0.10.14"
 			}
 		},
 		"es6-weak-map": {
@@ -3713,10 +3736,10 @@
 			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
 			"dev": true,
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.26",
-				"es6-iterator": "2.0.1",
-				"es6-symbol": "3.1.1"
+				"d": "1",
+				"es5-ext": "^0.10.14",
+				"es6-iterator": "^2.0.1",
+				"es6-symbol": "^3.1.1"
 			}
 		},
 		"escape-html": {
@@ -3737,11 +3760,11 @@
 			"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
 			"dev": true,
 			"requires": {
-				"esprima": "3.1.3",
-				"estraverse": "4.2.0",
-				"esutils": "2.0.2",
-				"optionator": "0.8.2",
-				"source-map": "0.6.1"
+				"esprima": "^3.1.3",
+				"estraverse": "^4.2.0",
+				"esutils": "^2.0.2",
+				"optionator": "^0.8.1",
+				"source-map": "~0.6.1"
 			},
 			"dependencies": {
 				"esprima": {
@@ -3765,10 +3788,10 @@
 			"integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
 			"dev": true,
 			"requires": {
-				"es6-map": "0.1.5",
-				"es6-weak-map": "2.0.2",
-				"esrecurse": "4.2.0",
-				"estraverse": "4.2.0"
+				"es6-map": "^0.1.3",
+				"es6-weak-map": "^2.0.1",
+				"esrecurse": "^4.1.0",
+				"estraverse": "^4.1.1"
 			}
 		},
 		"eslint": {
@@ -3777,44 +3800,44 @@
 			"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
 			"dev": true,
 			"requires": {
-				"ajv": "5.5.2",
-				"babel-code-frame": "6.26.0",
-				"chalk": "2.3.2",
-				"concat-stream": "1.6.2",
-				"cross-spawn": "5.1.0",
-				"debug": "3.1.0",
-				"doctrine": "2.1.0",
-				"eslint-scope": "3.7.1",
-				"eslint-visitor-keys": "1.0.0",
-				"espree": "3.5.4",
-				"esquery": "1.0.0",
-				"esutils": "2.0.2",
-				"file-entry-cache": "2.0.0",
-				"functional-red-black-tree": "1.0.1",
-				"glob": "7.1.2",
-				"globals": "11.4.0",
-				"ignore": "3.3.7",
-				"imurmurhash": "0.1.4",
-				"inquirer": "3.3.0",
-				"is-resolvable": "1.1.0",
-				"js-yaml": "3.9.1",
-				"json-stable-stringify-without-jsonify": "1.0.1",
-				"levn": "0.3.0",
-				"lodash": "4.17.5",
-				"minimatch": "3.0.4",
-				"mkdirp": "0.5.1",
-				"natural-compare": "1.4.0",
-				"optionator": "0.8.2",
-				"path-is-inside": "1.0.2",
-				"pluralize": "7.0.0",
-				"progress": "2.0.0",
-				"regexpp": "1.0.1",
-				"require-uncached": "1.0.3",
-				"semver": "5.4.1",
-				"strip-ansi": "4.0.0",
-				"strip-json-comments": "2.0.1",
+				"ajv": "^5.3.0",
+				"babel-code-frame": "^6.22.0",
+				"chalk": "^2.1.0",
+				"concat-stream": "^1.6.0",
+				"cross-spawn": "^5.1.0",
+				"debug": "^3.1.0",
+				"doctrine": "^2.1.0",
+				"eslint-scope": "^3.7.1",
+				"eslint-visitor-keys": "^1.0.0",
+				"espree": "^3.5.4",
+				"esquery": "^1.0.0",
+				"esutils": "^2.0.2",
+				"file-entry-cache": "^2.0.0",
+				"functional-red-black-tree": "^1.0.1",
+				"glob": "^7.1.2",
+				"globals": "^11.0.1",
+				"ignore": "^3.3.3",
+				"imurmurhash": "^0.1.4",
+				"inquirer": "^3.0.6",
+				"is-resolvable": "^1.0.0",
+				"js-yaml": "^3.9.1",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"levn": "^0.3.0",
+				"lodash": "^4.17.4",
+				"minimatch": "^3.0.2",
+				"mkdirp": "^0.5.1",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.8.2",
+				"path-is-inside": "^1.0.2",
+				"pluralize": "^7.0.0",
+				"progress": "^2.0.0",
+				"regexpp": "^1.0.1",
+				"require-uncached": "^1.0.3",
+				"semver": "^5.3.0",
+				"strip-ansi": "^4.0.0",
+				"strip-json-comments": "~2.0.1",
 				"table": "4.0.2",
-				"text-table": "0.2.0"
+				"text-table": "~0.2.0"
 			},
 			"dependencies": {
 				"ajv": {
@@ -3823,10 +3846,10 @@
 					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 					"dev": true,
 					"requires": {
-						"co": "4.6.0",
-						"fast-deep-equal": "1.0.0",
-						"fast-json-stable-stringify": "2.0.0",
-						"json-schema-traverse": "0.3.1"
+						"co": "^4.6.0",
+						"fast-deep-equal": "^1.0.0",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.3.0"
 					}
 				},
 				"ansi-regex": {
@@ -3841,7 +3864,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.0"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -3850,9 +3873,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"debug": {
@@ -3882,7 +3905,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"supports-color": {
@@ -3891,7 +3914,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -3902,10 +3925,10 @@
 			"integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
 			"dev": true,
 			"requires": {
-				"ignore": "3.3.7",
-				"minimatch": "3.0.4",
-				"resolve": "1.4.0",
-				"semver": "5.4.1"
+				"ignore": "^3.3.6",
+				"minimatch": "^3.0.4",
+				"resolve": "^1.3.3",
+				"semver": "^5.4.1"
 			}
 		},
 		"eslint-scope": {
@@ -3914,8 +3937,8 @@
 			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
 			"dev": true,
 			"requires": {
-				"esrecurse": "4.2.0",
-				"estraverse": "4.2.0"
+				"esrecurse": "^4.1.0",
+				"estraverse": "^4.1.1"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -3930,8 +3953,8 @@
 			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
 			"dev": true,
 			"requires": {
-				"acorn": "5.5.3",
-				"acorn-jsx": "3.0.1"
+				"acorn": "^5.5.0",
+				"acorn-jsx": "^3.0.0"
 			},
 			"dependencies": {
 				"acorn": {
@@ -3954,7 +3977,7 @@
 			"integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
 			"dev": true,
 			"requires": {
-				"estraverse": "4.2.0"
+				"estraverse": "^4.0.0"
 			}
 		},
 		"esrecurse": {
@@ -3963,8 +3986,8 @@
 			"integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
 			"dev": true,
 			"requires": {
-				"estraverse": "4.2.0",
-				"object-assign": "4.1.1"
+				"estraverse": "^4.1.0",
+				"object-assign": "^4.0.1"
 			}
 		},
 		"estraverse": {
@@ -3997,8 +4020,8 @@
 			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
 			"dev": true,
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.26"
+				"d": "1",
+				"es5-ext": "~0.10.14"
 			}
 		},
 		"eventemitter3": {
@@ -4019,7 +4042,7 @@
 			"integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
 			"dev": true,
 			"requires": {
-				"original": "1.0.0"
+				"original": ">=0.0.5"
 			}
 		},
 		"evp_bytestokey": {
@@ -4028,7 +4051,7 @@
 			"integrity": "sha1-SXtmrZ/vZc18CKYYCCS6FHa2blM=",
 			"dev": true,
 			"requires": {
-				"create-hash": "1.1.3"
+				"create-hash": "^1.1.1"
 			}
 		},
 		"exec-sh": {
@@ -4037,7 +4060,7 @@
 			"integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
 			"dev": true,
 			"requires": {
-				"merge": "1.2.0"
+				"merge": "^1.1.3"
 			}
 		},
 		"execa": {
@@ -4046,13 +4069,13 @@
 			"integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "5.1.0",
-				"get-stream": "3.0.0",
-				"is-stream": "1.1.0",
-				"npm-run-path": "2.0.2",
-				"p-finally": "1.0.0",
-				"signal-exit": "3.0.2",
-				"strip-eof": "1.0.0"
+				"cross-spawn": "^5.0.1",
+				"get-stream": "^3.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
 			}
 		},
 		"exit": {
@@ -4073,7 +4096,7 @@
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 			"dev": true,
 			"requires": {
-				"is-posix-bracket": "0.1.1"
+				"is-posix-bracket": "^0.1.0"
 			}
 		},
 		"expand-range": {
@@ -4082,7 +4105,7 @@
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"dev": true,
 			"requires": {
-				"fill-range": "2.2.3"
+				"fill-range": "^2.1.0"
 			}
 		},
 		"expect": {
@@ -4091,12 +4114,12 @@
 			"integrity": "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "3.2.1",
-				"jest-diff": "22.4.3",
-				"jest-get-type": "22.4.3",
-				"jest-matcher-utils": "22.4.3",
-				"jest-message-util": "22.4.3",
-				"jest-regex-util": "22.4.3"
+				"ansi-styles": "^3.2.0",
+				"jest-diff": "^22.4.3",
+				"jest-get-type": "^22.4.3",
+				"jest-matcher-utils": "^22.4.3",
+				"jest-message-util": "^22.4.3",
+				"jest-regex-util": "^22.4.3"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -4111,7 +4134,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.0"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -4120,9 +4143,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -4137,10 +4160,10 @@
 					"integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
 					"dev": true,
 					"requires": {
-						"chalk": "2.3.2",
-						"diff": "3.3.0",
-						"jest-get-type": "22.4.3",
-						"pretty-format": "22.4.3"
+						"chalk": "^2.0.1",
+						"diff": "^3.2.0",
+						"jest-get-type": "^22.4.3",
+						"pretty-format": "^22.4.3"
 					}
 				},
 				"jest-matcher-utils": {
@@ -4149,9 +4172,9 @@
 					"integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
 					"dev": true,
 					"requires": {
-						"chalk": "2.3.2",
-						"jest-get-type": "22.4.3",
-						"pretty-format": "22.4.3"
+						"chalk": "^2.0.1",
+						"jest-get-type": "^22.4.3",
+						"pretty-format": "^22.4.3"
 					}
 				},
 				"jest-message-util": {
@@ -4160,11 +4183,11 @@
 					"integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "7.0.0-beta.42",
-						"chalk": "2.3.2",
-						"micromatch": "2.3.11",
-						"slash": "1.0.0",
-						"stack-utils": "1.0.1"
+						"@babel/code-frame": "^7.0.0-beta.35",
+						"chalk": "^2.0.1",
+						"micromatch": "^2.3.11",
+						"slash": "^1.0.0",
+						"stack-utils": "^1.0.1"
 					}
 				},
 				"jest-regex-util": {
@@ -4179,8 +4202,8 @@
 					"integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0",
-						"ansi-styles": "3.2.1"
+						"ansi-regex": "^3.0.0",
+						"ansi-styles": "^3.2.0"
 					}
 				},
 				"supports-color": {
@@ -4189,7 +4212,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -4200,34 +4223,34 @@
 			"integrity": "sha1-urZdDwOqgMNYQIly/HAPkWlEtmI=",
 			"dev": true,
 			"requires": {
-				"accepts": "1.3.3",
+				"accepts": "~1.3.3",
 				"array-flatten": "1.1.1",
 				"content-disposition": "0.5.2",
-				"content-type": "1.0.2",
+				"content-type": "~1.0.2",
 				"cookie": "0.3.1",
 				"cookie-signature": "1.0.6",
 				"debug": "2.6.7",
-				"depd": "1.1.1",
-				"encodeurl": "1.0.1",
-				"escape-html": "1.0.3",
-				"etag": "1.8.0",
-				"finalhandler": "1.0.4",
+				"depd": "~1.1.0",
+				"encodeurl": "~1.0.1",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.0",
+				"finalhandler": "~1.0.3",
 				"fresh": "0.5.0",
 				"merge-descriptors": "1.0.1",
-				"methods": "1.1.2",
-				"on-finished": "2.3.0",
-				"parseurl": "1.3.1",
+				"methods": "~1.1.2",
+				"on-finished": "~2.3.0",
+				"parseurl": "~1.3.1",
 				"path-to-regexp": "0.1.7",
-				"proxy-addr": "1.1.5",
+				"proxy-addr": "~1.1.4",
 				"qs": "6.4.0",
-				"range-parser": "1.2.0",
+				"range-parser": "~1.2.0",
 				"send": "0.15.3",
 				"serve-static": "1.12.3",
 				"setprototypeof": "1.0.3",
-				"statuses": "1.3.1",
-				"type-is": "1.6.15",
+				"statuses": "~1.3.1",
+				"type-is": "~1.6.15",
 				"utils-merge": "1.0.0",
-				"vary": "1.1.1"
+				"vary": "~1.1.1"
 			},
 			"dependencies": {
 				"array-flatten": {
@@ -4259,8 +4282,8 @@
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 			"dev": true,
 			"requires": {
-				"assign-symbols": "1.0.0",
-				"is-extendable": "1.0.1"
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -4269,7 +4292,7 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
-						"is-plain-object": "2.0.4"
+						"is-plain-object": "^2.0.4"
 					}
 				}
 			}
@@ -4280,9 +4303,9 @@
 			"integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
 			"dev": true,
 			"requires": {
-				"chardet": "0.4.2",
-				"iconv-lite": "0.4.19",
-				"tmp": "0.0.33"
+				"chardet": "^0.4.0",
+				"iconv-lite": "^0.4.17",
+				"tmp": "^0.0.33"
 			}
 		},
 		"extglob": {
@@ -4291,7 +4314,7 @@
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "1.0.0"
+				"is-extglob": "^1.0.0"
 			}
 		},
 		"extsprintf": {
@@ -4312,11 +4335,11 @@
 			"integrity": "sha512-4F75PTznkNtSKs2pbhtBwRkw8sRwa7LfXx5XaQJOe4IQ6yTjceLDTwM5gj1s80R2t/5WeDC1gVfm3jLE+l39Tw==",
 			"dev": true,
 			"requires": {
-				"@mrmlnc/readdir-enhanced": "2.2.1",
-				"glob-parent": "3.1.0",
-				"is-glob": "4.0.0",
-				"merge2": "1.2.1",
-				"micromatch": "3.1.10"
+				"@mrmlnc/readdir-enhanced": "^2.2.1",
+				"glob-parent": "^3.1.0",
+				"is-glob": "^4.0.0",
+				"merge2": "^1.2.1",
+				"micromatch": "^3.1.8"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -4337,16 +4360,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"repeat-element": "1.1.2",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -4355,7 +4378,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -4366,13 +4389,13 @@
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"dev": true,
 					"requires": {
-						"debug": "2.6.8",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -4381,7 +4404,7 @@
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
@@ -4390,7 +4413,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-descriptor": {
@@ -4399,9 +4422,9 @@
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							}
 						},
 						"kind-of": {
@@ -4418,14 +4441,14 @@
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"dev": true,
 					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -4434,7 +4457,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
@@ -4443,7 +4466,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -4454,10 +4477,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -4466,7 +4489,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -4477,8 +4500,8 @@
 					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 					"dev": true,
 					"requires": {
-						"is-glob": "3.1.0",
-						"path-dirname": "1.0.2"
+						"is-glob": "^3.1.0",
+						"path-dirname": "^1.0.0"
 					},
 					"dependencies": {
 						"is-glob": {
@@ -4487,7 +4510,7 @@
 							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 							"dev": true,
 							"requires": {
-								"is-extglob": "2.1.1"
+								"is-extglob": "^2.1.0"
 							}
 						}
 					}
@@ -4498,7 +4521,7 @@
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -4507,7 +4530,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -4518,7 +4541,7 @@
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -4527,7 +4550,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -4544,7 +4567,7 @@
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "2.1.1"
+						"is-extglob": "^2.1.1"
 					}
 				},
 				"is-number": {
@@ -4553,7 +4576,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -4562,7 +4585,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -4585,19 +4608,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.9",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					}
 				}
 			}
@@ -4620,7 +4643,7 @@
 			"integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
 			"dev": true,
 			"requires": {
-				"websocket-driver": "0.6.5"
+				"websocket-driver": ">=0.5.1"
 			}
 		},
 		"fb-watchman": {
@@ -4629,7 +4652,7 @@
 			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
 			"dev": true,
 			"requires": {
-				"bser": "2.0.0"
+				"bser": "^2.0.0"
 			}
 		},
 		"figures": {
@@ -4638,7 +4661,7 @@
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "1.0.5"
+				"escape-string-regexp": "^1.0.5"
 			}
 		},
 		"file-entry-cache": {
@@ -4647,8 +4670,8 @@
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
 			"dev": true,
 			"requires": {
-				"flat-cache": "1.3.0",
-				"object-assign": "4.1.1"
+				"flat-cache": "^1.2.1",
+				"object-assign": "^4.0.1"
 			}
 		},
 		"filename-regex": {
@@ -4663,8 +4686,8 @@
 			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.2",
-				"minimatch": "3.0.4"
+				"glob": "^7.0.3",
+				"minimatch": "^3.0.3"
 			}
 		},
 		"fill-range": {
@@ -4673,11 +4696,11 @@
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
 			"dev": true,
 			"requires": {
-				"is-number": "2.1.0",
-				"isobject": "2.1.0",
-				"randomatic": "1.1.7",
-				"repeat-element": "1.1.2",
-				"repeat-string": "1.6.1"
+				"is-number": "^2.1.0",
+				"isobject": "^2.0.0",
+				"randomatic": "^1.1.3",
+				"repeat-element": "^1.1.2",
+				"repeat-string": "^1.5.2"
 			}
 		},
 		"finalhandler": {
@@ -4687,12 +4710,12 @@
 			"dev": true,
 			"requires": {
 				"debug": "2.6.8",
-				"encodeurl": "1.0.1",
-				"escape-html": "1.0.3",
-				"on-finished": "2.3.0",
-				"parseurl": "1.3.1",
-				"statuses": "1.3.1",
-				"unpipe": "1.0.0"
+				"encodeurl": "~1.0.1",
+				"escape-html": "~1.0.3",
+				"on-finished": "~2.3.0",
+				"parseurl": "~1.3.1",
+				"statuses": "~1.3.1",
+				"unpipe": "~1.0.0"
 			}
 		},
 		"find-cache-dir": {
@@ -4701,9 +4724,9 @@
 			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
 			"dev": true,
 			"requires": {
-				"commondir": "1.0.1",
-				"make-dir": "1.2.0",
-				"pkg-dir": "2.0.0"
+				"commondir": "^1.0.1",
+				"make-dir": "^1.0.0",
+				"pkg-dir": "^2.0.0"
 			}
 		},
 		"find-parent-dir": {
@@ -4718,7 +4741,7 @@
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"dev": true,
 			"requires": {
-				"locate-path": "2.0.0"
+				"locate-path": "^2.0.0"
 			}
 		},
 		"flat-cache": {
@@ -4727,10 +4750,10 @@
 			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
 			"dev": true,
 			"requires": {
-				"circular-json": "0.3.3",
-				"del": "2.2.2",
-				"graceful-fs": "4.1.11",
-				"write": "0.2.1"
+				"circular-json": "^0.3.1",
+				"del": "^2.0.2",
+				"graceful-fs": "^4.1.2",
+				"write": "^0.2.1"
 			},
 			"dependencies": {
 				"del": {
@@ -4739,13 +4762,13 @@
 					"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
 					"dev": true,
 					"requires": {
-						"globby": "5.0.0",
-						"is-path-cwd": "1.0.0",
-						"is-path-in-cwd": "1.0.0",
-						"object-assign": "4.1.1",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"rimraf": "2.6.1"
+						"globby": "^5.0.0",
+						"is-path-cwd": "^1.0.0",
+						"is-path-in-cwd": "^1.0.0",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"rimraf": "^2.2.8"
 					}
 				},
 				"globby": {
@@ -4754,12 +4777,12 @@
 					"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
 					"dev": true,
 					"requires": {
-						"array-union": "1.0.2",
-						"arrify": "1.0.1",
-						"glob": "7.1.2",
-						"object-assign": "4.1.1",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"array-union": "^1.0.1",
+						"arrify": "^1.0.0",
+						"glob": "^7.0.3",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"pify": {
@@ -4782,7 +4805,7 @@
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 			"dev": true,
 			"requires": {
-				"for-in": "1.0.2"
+				"for-in": "^1.0.1"
 			}
 		},
 		"foreach": {
@@ -4803,9 +4826,9 @@
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"dev": true,
 			"requires": {
-				"asynckit": "0.4.0",
+				"asynckit": "^0.4.0",
 				"combined-stream": "1.0.6",
-				"mime-types": "2.1.16"
+				"mime-types": "^2.1.12"
 			},
 			"dependencies": {
 				"combined-stream": {
@@ -4814,7 +4837,7 @@
 					"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 					"dev": true,
 					"requires": {
-						"delayed-stream": "1.0.0"
+						"delayed-stream": "~1.0.0"
 					}
 				}
 			}
@@ -4831,7 +4854,7 @@
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
 			"dev": true,
 			"requires": {
-				"map-cache": "0.2.2"
+				"map-cache": "^0.2.2"
 			}
 		},
 		"fresh": {
@@ -4846,9 +4869,9 @@
 			"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"jsonfile": "4.0.0",
-				"universalify": "0.1.1"
+				"graceful-fs": "^4.1.2",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
 			}
 		},
 		"fs.realpath": {
@@ -4864,8 +4887,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "2.6.2",
-				"node-pre-gyp": "0.6.36"
+				"nan": "^2.3.0",
+				"node-pre-gyp": "^0.6.36"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -4882,8 +4905,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"co": "4.6.0",
-						"json-stable-stringify": "1.0.1"
+						"co": "^4.6.0",
+						"json-stable-stringify": "^1.0.1"
 					}
 				},
 				"ansi-regex": {
@@ -4906,8 +4929,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"delegates": "1.0.0",
-						"readable-stream": "2.2.9"
+						"delegates": "^1.0.0",
+						"readable-stream": "^2.0.6"
 					}
 				},
 				"asn1": {
@@ -4958,7 +4981,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"tweetnacl": "0.14.5"
+						"tweetnacl": "^0.14.3"
 					}
 				},
 				"block-stream": {
@@ -4967,7 +4990,7 @@
 					"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
 					"dev": true,
 					"requires": {
-						"inherits": "2.0.3"
+						"inherits": "~2.0.0"
 					}
 				},
 				"boom": {
@@ -4976,7 +4999,7 @@
 					"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
 					"dev": true,
 					"requires": {
-						"hoek": "2.16.3"
+						"hoek": "2.x.x"
 					}
 				},
 				"brace-expansion": {
@@ -4985,7 +5008,7 @@
 					"integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
 					"dev": true,
 					"requires": {
-						"balanced-match": "0.4.2",
+						"balanced-match": "^0.4.1",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -5021,7 +5044,7 @@
 					"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
 					"dev": true,
 					"requires": {
-						"delayed-stream": "1.0.0"
+						"delayed-stream": "~1.0.0"
 					}
 				},
 				"concat-map": {
@@ -5049,7 +5072,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"boom": "2.10.1"
+						"boom": "2.x.x"
 					}
 				},
 				"dashdash": {
@@ -5059,7 +5082,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"assert-plus": "1.0.0"
+						"assert-plus": "^1.0.0"
 					},
 					"dependencies": {
 						"assert-plus": {
@@ -5108,7 +5131,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"jsbn": "0.1.1"
+						"jsbn": "~0.1.0"
 					}
 				},
 				"extend": {
@@ -5138,9 +5161,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"asynckit": "0.4.0",
-						"combined-stream": "1.0.5",
-						"mime-types": "2.1.15"
+						"asynckit": "^0.4.0",
+						"combined-stream": "^1.0.5",
+						"mime-types": "^2.1.12"
 					}
 				},
 				"fs.realpath": {
@@ -5155,10 +5178,10 @@
 					"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"inherits": "2.0.3",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.1"
+						"graceful-fs": "^4.1.2",
+						"inherits": "~2.0.0",
+						"mkdirp": ">=0.5 0",
+						"rimraf": "2"
 					}
 				},
 				"fstream-ignore": {
@@ -5168,9 +5191,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"fstream": "1.0.11",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4"
+						"fstream": "^1.0.0",
+						"inherits": "2",
+						"minimatch": "^3.0.0"
 					}
 				},
 				"gauge": {
@@ -5180,14 +5203,14 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"aproba": "1.1.1",
-						"console-control-strings": "1.1.0",
-						"has-unicode": "2.0.1",
-						"object-assign": "4.1.1",
-						"signal-exit": "3.0.2",
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wide-align": "1.1.2"
+						"aproba": "^1.0.3",
+						"console-control-strings": "^1.0.0",
+						"has-unicode": "^2.0.0",
+						"object-assign": "^4.1.0",
+						"signal-exit": "^3.0.0",
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wide-align": "^1.1.0"
 					}
 				},
 				"getpass": {
@@ -5197,7 +5220,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"assert-plus": "1.0.0"
+						"assert-plus": "^1.0.0"
 					},
 					"dependencies": {
 						"assert-plus": {
@@ -5215,12 +5238,12 @@
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"dev": true,
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"graceful-fs": {
@@ -5243,8 +5266,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"ajv": "4.11.8",
-						"har-schema": "1.0.5"
+						"ajv": "^4.9.1",
+						"har-schema": "^1.0.5"
 					}
 				},
 				"has-unicode": {
@@ -5261,10 +5284,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"boom": "2.10.1",
-						"cryptiles": "2.0.5",
-						"hoek": "2.16.3",
-						"sntp": "1.0.9"
+						"boom": "2.x.x",
+						"cryptiles": "2.x.x",
+						"hoek": "2.x.x",
+						"sntp": "1.x.x"
 					}
 				},
 				"hoek": {
@@ -5280,9 +5303,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"assert-plus": "0.2.0",
-						"jsprim": "1.4.0",
-						"sshpk": "1.13.0"
+						"assert-plus": "^0.2.0",
+						"jsprim": "^1.2.2",
+						"sshpk": "^1.7.0"
 					}
 				},
 				"inflight": {
@@ -5291,8 +5314,8 @@
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"dev": true,
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
@@ -5314,7 +5337,7 @@
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"is-typedarray": {
@@ -5344,7 +5367,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"jsbn": "0.1.1"
+						"jsbn": "~0.1.0"
 					}
 				},
 				"jsbn": {
@@ -5368,7 +5391,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"jsonify": "0.0.0"
+						"jsonify": "~0.0.0"
 					}
 				},
 				"json-stringify-safe": {
@@ -5419,7 +5442,7 @@
 					"integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
 					"dev": true,
 					"requires": {
-						"mime-db": "1.27.0"
+						"mime-db": "~1.27.0"
 					}
 				},
 				"minimatch": {
@@ -5428,7 +5451,7 @@
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"dev": true,
 					"requires": {
-						"brace-expansion": "1.1.7"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
@@ -5460,15 +5483,15 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"mkdirp": "0.5.1",
-						"nopt": "4.0.1",
-						"npmlog": "4.1.0",
-						"rc": "1.2.1",
-						"request": "2.81.0",
-						"rimraf": "2.6.1",
-						"semver": "5.3.0",
-						"tar": "2.2.1",
-						"tar-pack": "3.4.0"
+						"mkdirp": "^0.5.1",
+						"nopt": "^4.0.1",
+						"npmlog": "^4.0.2",
+						"rc": "^1.1.7",
+						"request": "^2.81.0",
+						"rimraf": "^2.6.1",
+						"semver": "^5.3.0",
+						"tar": "^2.2.1",
+						"tar-pack": "^3.4.0"
 					}
 				},
 				"nopt": {
@@ -5478,8 +5501,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"abbrev": "1.1.0",
-						"osenv": "0.1.4"
+						"abbrev": "1",
+						"osenv": "^0.1.4"
 					}
 				},
 				"npmlog": {
@@ -5489,10 +5512,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"are-we-there-yet": "1.1.4",
-						"console-control-strings": "1.1.0",
-						"gauge": "2.7.4",
-						"set-blocking": "2.0.0"
+						"are-we-there-yet": "~1.1.2",
+						"console-control-strings": "~1.1.0",
+						"gauge": "~2.7.3",
+						"set-blocking": "~2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -5521,7 +5544,7 @@
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"dev": true,
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"os-homedir": {
@@ -5545,8 +5568,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"os-homedir": "1.0.2",
-						"os-tmpdir": "1.0.2"
+						"os-homedir": "^1.0.0",
+						"os-tmpdir": "^1.0.0"
 					}
 				},
 				"path-is-absolute": {
@@ -5589,10 +5612,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "0.4.2",
-						"ini": "1.3.4",
-						"minimist": "1.2.0",
-						"strip-json-comments": "2.0.1"
+						"deep-extend": "~0.4.0",
+						"ini": "~1.3.0",
+						"minimist": "^1.2.0",
+						"strip-json-comments": "~2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
@@ -5610,13 +5633,13 @@
 					"integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
 					"dev": true,
 					"requires": {
-						"buffer-shims": "1.0.0",
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "1.0.7",
-						"string_decoder": "1.0.1",
-						"util-deprecate": "1.0.2"
+						"buffer-shims": "~1.0.0",
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~1.0.6",
+						"string_decoder": "~1.0.0",
+						"util-deprecate": "~1.0.1"
 					}
 				},
 				"request": {
@@ -5626,28 +5649,28 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"aws-sign2": "0.6.0",
-						"aws4": "1.6.0",
-						"caseless": "0.12.0",
-						"combined-stream": "1.0.5",
-						"extend": "3.0.1",
-						"forever-agent": "0.6.1",
-						"form-data": "2.1.4",
-						"har-validator": "4.2.1",
-						"hawk": "3.1.3",
-						"http-signature": "1.1.1",
-						"is-typedarray": "1.0.0",
-						"isstream": "0.1.2",
-						"json-stringify-safe": "5.0.1",
-						"mime-types": "2.1.15",
-						"oauth-sign": "0.8.2",
-						"performance-now": "0.2.0",
-						"qs": "6.4.0",
-						"safe-buffer": "5.0.1",
-						"stringstream": "0.0.5",
-						"tough-cookie": "2.3.2",
-						"tunnel-agent": "0.6.0",
-						"uuid": "3.0.1"
+						"aws-sign2": "~0.6.0",
+						"aws4": "^1.2.1",
+						"caseless": "~0.12.0",
+						"combined-stream": "~1.0.5",
+						"extend": "~3.0.0",
+						"forever-agent": "~0.6.1",
+						"form-data": "~2.1.1",
+						"har-validator": "~4.2.1",
+						"hawk": "~3.1.3",
+						"http-signature": "~1.1.0",
+						"is-typedarray": "~1.0.0",
+						"isstream": "~0.1.2",
+						"json-stringify-safe": "~5.0.1",
+						"mime-types": "~2.1.7",
+						"oauth-sign": "~0.8.1",
+						"performance-now": "^0.2.0",
+						"qs": "~6.4.0",
+						"safe-buffer": "^5.0.1",
+						"stringstream": "~0.0.4",
+						"tough-cookie": "~2.3.0",
+						"tunnel-agent": "^0.6.0",
+						"uuid": "^3.0.0"
 					}
 				},
 				"rimraf": {
@@ -5656,7 +5679,7 @@
 					"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
 					"dev": true,
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.0.5"
 					}
 				},
 				"safe-buffer": {
@@ -5693,7 +5716,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"hoek": "2.16.3"
+						"hoek": "2.x.x"
 					}
 				},
 				"sshpk": {
@@ -5703,15 +5726,15 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"asn1": "0.2.3",
-						"assert-plus": "1.0.0",
-						"bcrypt-pbkdf": "1.0.1",
-						"dashdash": "1.14.1",
-						"ecc-jsbn": "0.1.1",
-						"getpass": "0.1.7",
-						"jodid25519": "1.0.2",
-						"jsbn": "0.1.1",
-						"tweetnacl": "0.14.5"
+						"asn1": "~0.2.3",
+						"assert-plus": "^1.0.0",
+						"bcrypt-pbkdf": "^1.0.0",
+						"dashdash": "^1.12.0",
+						"ecc-jsbn": "~0.1.1",
+						"getpass": "^0.1.1",
+						"jodid25519": "^1.0.0",
+						"jsbn": "~0.1.0",
+						"tweetnacl": "~0.14.0"
 					},
 					"dependencies": {
 						"assert-plus": {
@@ -5729,9 +5752,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"string_decoder": {
@@ -5740,7 +5763,7 @@
 					"integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
 					"dev": true,
 					"requires": {
-						"safe-buffer": "5.0.1"
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"stringstream": {
@@ -5756,7 +5779,7 @@
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-json-comments": {
@@ -5772,9 +5795,9 @@
 					"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
 					"dev": true,
 					"requires": {
-						"block-stream": "0.0.9",
-						"fstream": "1.0.11",
-						"inherits": "2.0.3"
+						"block-stream": "*",
+						"fstream": "^1.0.2",
+						"inherits": "2"
 					}
 				},
 				"tar-pack": {
@@ -5784,14 +5807,14 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"debug": "2.6.8",
-						"fstream": "1.0.11",
-						"fstream-ignore": "1.0.5",
-						"once": "1.4.0",
-						"readable-stream": "2.2.9",
-						"rimraf": "2.6.1",
-						"tar": "2.2.1",
-						"uid-number": "0.0.6"
+						"debug": "^2.2.0",
+						"fstream": "^1.0.10",
+						"fstream-ignore": "^1.0.5",
+						"once": "^1.3.3",
+						"readable-stream": "^2.1.4",
+						"rimraf": "^2.5.1",
+						"tar": "^2.2.1",
+						"uid-number": "^0.0.6"
 					}
 				},
 				"tough-cookie": {
@@ -5801,7 +5824,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"punycode": "1.4.1"
+						"punycode": "^1.4.1"
 					}
 				},
 				"tunnel-agent": {
@@ -5811,7 +5834,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safe-buffer": "5.0.1"
+						"safe-buffer": "^5.0.1"
 					}
 				},
 				"tweetnacl": {
@@ -5858,7 +5881,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"string-width": "1.0.2"
+						"string-width": "^1.0.2"
 					}
 				},
 				"wrappy": {
@@ -5887,14 +5910,14 @@
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 			"dev": true,
 			"requires": {
-				"aproba": "1.2.0",
-				"console-control-strings": "1.1.0",
-				"has-unicode": "2.0.1",
-				"object-assign": "4.1.1",
-				"signal-exit": "3.0.2",
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1",
-				"wide-align": "1.1.2"
+				"aproba": "^1.0.3",
+				"console-control-strings": "^1.0.0",
+				"has-unicode": "^2.0.0",
+				"object-assign": "^4.1.0",
+				"signal-exit": "^3.0.0",
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1",
+				"wide-align": "^1.1.0"
 			},
 			"dependencies": {
 				"is-fullwidth-code-point": {
@@ -5903,7 +5926,7 @@
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"string-width": {
@@ -5912,9 +5935,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				}
 			}
@@ -5937,11 +5960,11 @@
 			"integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "2.5.0",
-				"meow": "3.7.0",
-				"normalize-package-data": "2.4.0",
-				"parse-github-repo-url": "1.4.1",
-				"through2": "2.0.3"
+				"hosted-git-info": "^2.1.4",
+				"meow": "^3.3.0",
+				"normalize-package-data": "^2.3.0",
+				"parse-github-repo-url": "^1.3.0",
+				"through2": "^2.0.0"
 			}
 		},
 		"get-port": {
@@ -5974,7 +5997,7 @@
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			},
 			"dependencies": {
 				"assert-plus": {
@@ -5991,11 +6014,11 @@
 			"integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
 			"dev": true,
 			"requires": {
-				"dargs": "4.1.0",
-				"lodash.template": "4.4.0",
-				"meow": "4.0.0",
-				"split2": "2.2.0",
-				"through2": "2.0.3"
+				"dargs": "^4.0.1",
+				"lodash.template": "^4.0.2",
+				"meow": "^4.0.0",
+				"split2": "^2.0.0",
+				"through2": "^2.0.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -6010,9 +6033,9 @@
 					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0",
-						"map-obj": "2.0.0",
-						"quick-lru": "1.1.0"
+						"camelcase": "^4.1.0",
+						"map-obj": "^2.0.0",
+						"quick-lru": "^1.0.0"
 					}
 				},
 				"indent-string": {
@@ -6027,10 +6050,10 @@
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "4.0.0",
-						"pify": "3.0.0",
-						"strip-bom": "3.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
 					}
 				},
 				"map-obj": {
@@ -6045,15 +6068,15 @@
 					"integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
 					"dev": true,
 					"requires": {
-						"camelcase-keys": "4.2.0",
-						"decamelize-keys": "1.1.0",
-						"loud-rejection": "1.6.0",
-						"minimist": "1.2.0",
-						"minimist-options": "3.0.2",
-						"normalize-package-data": "2.4.0",
-						"read-pkg-up": "3.0.0",
-						"redent": "2.0.0",
-						"trim-newlines": "2.0.0"
+						"camelcase-keys": "^4.0.0",
+						"decamelize-keys": "^1.0.0",
+						"loud-rejection": "^1.0.0",
+						"minimist": "^1.1.3",
+						"minimist-options": "^3.0.1",
+						"normalize-package-data": "^2.3.4",
+						"read-pkg-up": "^3.0.0",
+						"redent": "^2.0.0",
+						"trim-newlines": "^2.0.0"
 					}
 				},
 				"minimist": {
@@ -6068,8 +6091,8 @@
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 					"dev": true,
 					"requires": {
-						"error-ex": "1.3.1",
-						"json-parse-better-errors": "1.0.1"
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
 					}
 				},
 				"path-type": {
@@ -6078,7 +6101,7 @@
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 					"dev": true,
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"read-pkg": {
@@ -6087,9 +6110,9 @@
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "4.0.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "3.0.0"
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -6098,8 +6121,8 @@
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 					"dev": true,
 					"requires": {
-						"find-up": "2.1.0",
-						"read-pkg": "3.0.0"
+						"find-up": "^2.0.0",
+						"read-pkg": "^3.0.0"
 					}
 				},
 				"redent": {
@@ -6108,8 +6131,8 @@
 					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
 					"dev": true,
 					"requires": {
-						"indent-string": "3.2.0",
-						"strip-indent": "2.0.0"
+						"indent-string": "^3.0.0",
+						"strip-indent": "^2.0.0"
 					}
 				},
 				"strip-bom": {
@@ -6132,8 +6155,8 @@
 			"integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
 			"dev": true,
 			"requires": {
-				"gitconfiglocal": "1.0.0",
-				"pify": "2.3.0"
+				"gitconfiglocal": "^1.0.0",
+				"pify": "^2.3.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -6150,8 +6173,8 @@
 			"integrity": "sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==",
 			"dev": true,
 			"requires": {
-				"meow": "4.0.0",
-				"semver": "5.5.0"
+				"meow": "^4.0.0",
+				"semver": "^5.5.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -6166,9 +6189,9 @@
 					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0",
-						"map-obj": "2.0.0",
-						"quick-lru": "1.1.0"
+						"camelcase": "^4.1.0",
+						"map-obj": "^2.0.0",
+						"quick-lru": "^1.0.0"
 					}
 				},
 				"indent-string": {
@@ -6183,10 +6206,10 @@
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "4.0.0",
-						"pify": "3.0.0",
-						"strip-bom": "3.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
 					}
 				},
 				"map-obj": {
@@ -6201,15 +6224,15 @@
 					"integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
 					"dev": true,
 					"requires": {
-						"camelcase-keys": "4.2.0",
-						"decamelize-keys": "1.1.0",
-						"loud-rejection": "1.6.0",
-						"minimist": "1.2.0",
-						"minimist-options": "3.0.2",
-						"normalize-package-data": "2.4.0",
-						"read-pkg-up": "3.0.0",
-						"redent": "2.0.0",
-						"trim-newlines": "2.0.0"
+						"camelcase-keys": "^4.0.0",
+						"decamelize-keys": "^1.0.0",
+						"loud-rejection": "^1.0.0",
+						"minimist": "^1.1.3",
+						"minimist-options": "^3.0.1",
+						"normalize-package-data": "^2.3.4",
+						"read-pkg-up": "^3.0.0",
+						"redent": "^2.0.0",
+						"trim-newlines": "^2.0.0"
 					}
 				},
 				"minimist": {
@@ -6224,8 +6247,8 @@
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 					"dev": true,
 					"requires": {
-						"error-ex": "1.3.1",
-						"json-parse-better-errors": "1.0.1"
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
 					}
 				},
 				"path-type": {
@@ -6234,7 +6257,7 @@
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 					"dev": true,
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"read-pkg": {
@@ -6243,9 +6266,9 @@
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "4.0.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "3.0.0"
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -6254,8 +6277,8 @@
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 					"dev": true,
 					"requires": {
-						"find-up": "2.1.0",
-						"read-pkg": "3.0.0"
+						"find-up": "^2.0.0",
+						"read-pkg": "^3.0.0"
 					}
 				},
 				"redent": {
@@ -6264,8 +6287,8 @@
 					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
 					"dev": true,
 					"requires": {
-						"indent-string": "3.2.0",
-						"strip-indent": "2.0.0"
+						"indent-string": "^3.0.0",
+						"strip-indent": "^2.0.0"
 					}
 				},
 				"semver": {
@@ -6294,7 +6317,7 @@
 			"integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
 			"dev": true,
 			"requires": {
-				"ini": "1.3.5"
+				"ini": "^1.3.2"
 			}
 		},
 		"glob": {
@@ -6303,12 +6326,12 @@
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 			"dev": true,
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"glob-base": {
@@ -6317,8 +6340,8 @@
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
 			"dev": true,
 			"requires": {
-				"glob-parent": "2.0.0",
-				"is-glob": "2.0.1"
+				"glob-parent": "^2.0.0",
+				"is-glob": "^2.0.0"
 			}
 		},
 		"glob-parent": {
@@ -6327,7 +6350,7 @@
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
 			"dev": true,
 			"requires": {
-				"is-glob": "2.0.1"
+				"is-glob": "^2.0.0"
 			}
 		},
 		"glob-to-regexp": {
@@ -6342,8 +6365,8 @@
 			"integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
 			"dev": true,
 			"requires": {
-				"min-document": "2.19.0",
-				"process": "0.5.2"
+				"min-document": "^2.19.0",
+				"process": "~0.5.1"
 			},
 			"dependencies": {
 				"process": {
@@ -6366,11 +6389,11 @@
 			"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 			"dev": true,
 			"requires": {
-				"array-union": "1.0.2",
-				"glob": "7.1.2",
-				"object-assign": "4.1.1",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1"
+				"array-union": "^1.0.1",
+				"glob": "^7.0.3",
+				"object-assign": "^4.0.1",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -6387,17 +6410,17 @@
 			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
 			"dev": true,
 			"requires": {
-				"create-error-class": "3.0.2",
-				"duplexer3": "0.1.4",
-				"get-stream": "3.0.0",
-				"is-redirect": "1.0.0",
-				"is-retry-allowed": "1.1.0",
-				"is-stream": "1.1.0",
-				"lowercase-keys": "1.0.1",
-				"safe-buffer": "5.1.1",
-				"timed-out": "4.0.1",
-				"unzip-response": "2.0.1",
-				"url-parse-lax": "1.0.0"
+				"create-error-class": "^3.0.0",
+				"duplexer3": "^0.1.4",
+				"get-stream": "^3.0.0",
+				"is-redirect": "^1.0.0",
+				"is-retry-allowed": "^1.0.0",
+				"is-stream": "^1.0.0",
+				"lowercase-keys": "^1.0.0",
+				"safe-buffer": "^5.0.1",
+				"timed-out": "^4.0.0",
+				"unzip-response": "^2.0.1",
+				"url-parse-lax": "^1.0.0"
 			}
 		},
 		"graceful-fs": {
@@ -6424,10 +6447,10 @@
 			"integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
 			"dev": true,
 			"requires": {
-				"async": "1.5.2",
-				"optimist": "0.6.1",
-				"source-map": "0.4.4",
-				"uglify-js": "2.8.29"
+				"async": "^1.4.0",
+				"optimist": "^0.6.1",
+				"source-map": "^0.4.4",
+				"uglify-js": "^2.6"
 			},
 			"dependencies": {
 				"async": {
@@ -6442,7 +6465,7 @@
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
 					"dev": true,
 					"requires": {
-						"amdefine": "1.0.1"
+						"amdefine": ">=0.0.4"
 					}
 				}
 			}
@@ -6459,8 +6482,8 @@
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
 			"dev": true,
 			"requires": {
-				"ajv": "5.2.2",
-				"har-schema": "2.0.0"
+				"ajv": "^5.1.0",
+				"har-schema": "^2.0.0"
 			}
 		},
 		"has": {
@@ -6469,7 +6492,7 @@
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
 			"dev": true,
 			"requires": {
-				"function-bind": "1.1.1"
+				"function-bind": "^1.0.2"
 			}
 		},
 		"has-ansi": {
@@ -6478,7 +6501,7 @@
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"has-flag": {
@@ -6499,9 +6522,9 @@
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
 			"dev": true,
 			"requires": {
-				"get-value": "2.0.6",
-				"has-values": "1.0.0",
-				"isobject": "3.0.1"
+				"get-value": "^2.0.6",
+				"has-values": "^1.0.0",
+				"isobject": "^3.0.0"
 			},
 			"dependencies": {
 				"isobject": {
@@ -6518,8 +6541,8 @@
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
 			"dev": true,
 			"requires": {
-				"is-number": "3.0.0",
-				"kind-of": "4.0.0"
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -6528,7 +6551,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -6537,7 +6560,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -6548,7 +6571,7 @@
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.5"
+						"is-buffer": "^1.1.5"
 					}
 				}
 			}
@@ -6559,7 +6582,7 @@
 			"integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3"
+				"inherits": "^2.0.1"
 			}
 		},
 		"hash.js": {
@@ -6568,8 +6591,8 @@
 			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0"
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.0"
 			}
 		},
 		"hawk": {
@@ -6578,10 +6601,10 @@
 			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
 			"dev": true,
 			"requires": {
-				"boom": "4.3.1",
-				"cryptiles": "3.1.2",
-				"hoek": "4.2.1",
-				"sntp": "2.1.0"
+				"boom": "4.x.x",
+				"cryptiles": "3.x.x",
+				"hoek": "4.x.x",
+				"sntp": "2.x.x"
 			}
 		},
 		"hmac-drbg": {
@@ -6590,9 +6613,9 @@
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
 			"dev": true,
 			"requires": {
-				"hash.js": "1.1.3",
-				"minimalistic-assert": "1.0.0",
-				"minimalistic-crypto-utils": "1.0.1"
+				"hash.js": "^1.0.3",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
 		"hoek": {
@@ -6607,8 +6630,8 @@
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
 			"dev": true,
 			"requires": {
-				"os-homedir": "1.0.2",
-				"os-tmpdir": "1.0.2"
+				"os-homedir": "^1.0.0",
+				"os-tmpdir": "^1.0.1"
 			}
 		},
 		"hosted-git-info": {
@@ -6623,10 +6646,10 @@
 			"integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"obuf": "1.1.1",
-				"readable-stream": "2.3.3",
-				"wbuf": "1.7.2"
+				"inherits": "^2.0.1",
+				"obuf": "^1.0.0",
+				"readable-stream": "^2.0.1",
+				"wbuf": "^1.1.0"
 			}
 		},
 		"html-encoding-sniffer": {
@@ -6635,7 +6658,7 @@
 			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
 			"dev": true,
 			"requires": {
-				"whatwg-encoding": "1.0.3"
+				"whatwg-encoding": "^1.0.1"
 			}
 		},
 		"html-entities": {
@@ -6650,12 +6673,12 @@
 			"integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
 			"dev": true,
 			"requires": {
-				"domelementtype": "1.3.0",
-				"domhandler": "2.4.1",
-				"domutils": "1.5.1",
-				"entities": "1.1.1",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
+				"domelementtype": "^1.3.0",
+				"domhandler": "^2.3.0",
+				"domutils": "^1.5.1",
+				"entities": "^1.1.1",
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.2"
 			}
 		},
 		"http-deceiver": {
@@ -6673,7 +6696,7 @@
 				"depd": "1.1.1",
 				"inherits": "2.0.3",
 				"setprototypeof": "1.0.3",
-				"statuses": "1.3.1"
+				"statuses": ">= 1.3.1 < 2"
 			}
 		},
 		"http-proxy": {
@@ -6682,8 +6705,8 @@
 			"integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
 			"dev": true,
 			"requires": {
-				"eventemitter3": "1.2.0",
-				"requires-port": "1.0.0"
+				"eventemitter3": "1.x.x",
+				"requires-port": "1.x.x"
 			}
 		},
 		"http-proxy-middleware": {
@@ -6692,10 +6715,10 @@
 			"integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
 			"dev": true,
 			"requires": {
-				"http-proxy": "1.16.2",
-				"is-glob": "3.1.0",
-				"lodash": "4.17.5",
-				"micromatch": "2.3.11"
+				"http-proxy": "^1.16.2",
+				"is-glob": "^3.1.0",
+				"lodash": "^4.17.2",
+				"micromatch": "^2.3.11"
 			},
 			"dependencies": {
 				"is-extglob": {
@@ -6710,7 +6733,7 @@
 					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "2.1.1"
+						"is-extglob": "^2.1.0"
 					}
 				}
 			}
@@ -6721,9 +6744,9 @@
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.13.1"
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
 			}
 		},
 		"husky": {
@@ -6732,9 +6755,9 @@
 			"integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
 			"dev": true,
 			"requires": {
-				"is-ci": "1.0.10",
-				"normalize-path": "1.0.0",
-				"strip-indent": "2.0.0"
+				"is-ci": "^1.0.10",
+				"normalize-path": "^1.0.0",
+				"strip-indent": "^2.0.0"
 			}
 		},
 		"iconv-lite": {
@@ -6761,8 +6784,8 @@
 			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
 			"dev": true,
 			"requires": {
-				"pkg-dir": "2.0.0",
-				"resolve-cwd": "2.0.0"
+				"pkg-dir": "^2.0.0",
+				"resolve-cwd": "^2.0.0"
 			}
 		},
 		"imurmurhash": {
@@ -6777,7 +6800,7 @@
 			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 			"dev": true,
 			"requires": {
-				"repeating": "2.0.1"
+				"repeating": "^2.0.0"
 			}
 		},
 		"indexof": {
@@ -6792,8 +6815,8 @@
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -6814,20 +6837,20 @@
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "3.1.0",
-				"chalk": "2.3.2",
-				"cli-cursor": "2.1.0",
-				"cli-width": "2.2.0",
-				"external-editor": "2.1.0",
-				"figures": "2.0.0",
-				"lodash": "4.17.5",
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.0",
+				"cli-cursor": "^2.1.0",
+				"cli-width": "^2.0.0",
+				"external-editor": "^2.0.4",
+				"figures": "^2.0.0",
+				"lodash": "^4.3.0",
 				"mute-stream": "0.0.7",
-				"run-async": "2.3.0",
-				"rx-lite": "4.0.8",
-				"rx-lite-aggregates": "4.0.8",
-				"string-width": "2.1.1",
-				"strip-ansi": "4.0.0",
-				"through": "2.3.8"
+				"run-async": "^2.2.0",
+				"rx-lite": "^4.0.8",
+				"rx-lite-aggregates": "^4.0.8",
+				"string-width": "^2.1.0",
+				"strip-ansi": "^4.0.0",
+				"through": "^2.3.6"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -6842,7 +6865,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.0"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -6851,9 +6874,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -6868,7 +6891,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"supports-color": {
@@ -6877,7 +6900,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -6888,7 +6911,7 @@
 			"integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
 			"dev": true,
 			"requires": {
-				"meow": "3.7.0"
+				"meow": "^3.3.0"
 			}
 		},
 		"interpret": {
@@ -6903,7 +6926,7 @@
 			"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
 			"dev": true,
 			"requires": {
-				"loose-envify": "1.3.1"
+				"loose-envify": "^1.0.0"
 			}
 		},
 		"invert-kv": {
@@ -6930,7 +6953,7 @@
 			"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 			"dev": true,
 			"requires": {
-				"kind-of": "6.0.2"
+				"kind-of": "^6.0.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -6953,7 +6976,7 @@
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
 			"dev": true,
 			"requires": {
-				"binary-extensions": "1.9.0"
+				"binary-extensions": "^1.0.0"
 			}
 		},
 		"is-buffer": {
@@ -6968,7 +6991,7 @@
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"dev": true,
 			"requires": {
-				"builtin-modules": "1.1.1"
+				"builtin-modules": "^1.0.0"
 			}
 		},
 		"is-callable": {
@@ -6983,7 +7006,7 @@
 			"integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
 			"dev": true,
 			"requires": {
-				"ci-info": "1.0.0"
+				"ci-info": "^1.0.0"
 			}
 		},
 		"is-data-descriptor": {
@@ -6992,7 +7015,7 @@
 			"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 			"dev": true,
 			"requires": {
-				"kind-of": "6.0.2"
+				"kind-of": "^6.0.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -7015,9 +7038,9 @@
 			"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 			"dev": true,
 			"requires": {
-				"is-accessor-descriptor": "1.0.0",
-				"is-data-descriptor": "1.0.0",
-				"kind-of": "6.0.2"
+				"is-accessor-descriptor": "^1.0.0",
+				"is-data-descriptor": "^1.0.0",
+				"kind-of": "^6.0.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -7046,7 +7069,7 @@
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 			"dev": true,
 			"requires": {
-				"is-primitive": "2.0.0"
+				"is-primitive": "^2.0.0"
 			}
 		},
 		"is-extendable": {
@@ -7067,7 +7090,7 @@
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -7088,7 +7111,7 @@
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "1.0.0"
+				"is-extglob": "^1.0.0"
 			}
 		},
 		"is-number": {
@@ -7097,7 +7120,7 @@
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			}
 		},
 		"is-obj": {
@@ -7112,7 +7135,7 @@
 			"integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
 			"dev": true,
 			"requires": {
-				"symbol-observable": "0.2.4"
+				"symbol-observable": "^0.2.2"
 			}
 		},
 		"is-odd": {
@@ -7121,7 +7144,7 @@
 			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
 			"dev": true,
 			"requires": {
-				"is-number": "4.0.0"
+				"is-number": "^4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -7144,7 +7167,7 @@
 			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
 			"dev": true,
 			"requires": {
-				"is-path-inside": "1.0.0"
+				"is-path-inside": "^1.0.0"
 			}
 		},
 		"is-path-inside": {
@@ -7153,7 +7176,7 @@
 			"integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
 			"dev": true,
 			"requires": {
-				"path-is-inside": "1.0.2"
+				"path-is-inside": "^1.0.1"
 			}
 		},
 		"is-plain-obj": {
@@ -7168,7 +7191,7 @@
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
 			"dev": true,
 			"requires": {
-				"isobject": "3.0.1"
+				"isobject": "^3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -7209,7 +7232,7 @@
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
 			"dev": true,
 			"requires": {
-				"has": "1.0.1"
+				"has": "^1.0.1"
 			}
 		},
 		"is-regexp": {
@@ -7254,7 +7277,7 @@
 			"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
 			"dev": true,
 			"requires": {
-				"text-extensions": "1.7.0"
+				"text-extensions": "^1.0.0"
 			}
 		},
 		"is-typedarray": {
@@ -7308,42 +7331,18 @@
 			"integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
 			"dev": true,
 			"requires": {
-				"async": "2.5.0",
-				"compare-versions": "3.1.0",
-				"fileset": "2.0.3",
-				"istanbul-lib-coverage": "1.2.0",
-				"istanbul-lib-hook": "1.2.0",
-				"istanbul-lib-instrument": "1.10.1",
-				"istanbul-lib-report": "1.1.4",
-				"istanbul-lib-source-maps": "1.2.4",
-				"istanbul-reports": "1.3.0",
-				"js-yaml": "3.9.1",
-				"mkdirp": "0.5.1",
-				"once": "1.4.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"istanbul-lib-source-maps": {
-					"version": "1.2.4",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.4.tgz",
-					"integrity": "sha512-UzuK0g1wyQijiaYQxj/CdNycFhAd2TLtO2obKQMTZrZ1jzEMRY3rvpASEKkaxbRR6brvdovfA03znPa/pXcejg==",
-					"dev": true,
-					"requires": {
-						"debug": "3.1.0",
-						"istanbul-lib-coverage": "1.2.0",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.1",
-						"source-map": "0.5.6"
-					}
-				}
+				"async": "^2.1.4",
+				"compare-versions": "^3.1.0",
+				"fileset": "^2.0.2",
+				"istanbul-lib-coverage": "^1.2.0",
+				"istanbul-lib-hook": "^1.2.0",
+				"istanbul-lib-instrument": "^1.10.1",
+				"istanbul-lib-report": "^1.1.4",
+				"istanbul-lib-source-maps": "^1.2.4",
+				"istanbul-reports": "^1.3.0",
+				"js-yaml": "^3.7.0",
+				"mkdirp": "^0.5.1",
+				"once": "^1.4.0"
 			}
 		},
 		"istanbul-lib-coverage": {
@@ -7358,7 +7357,7 @@
 			"integrity": "sha512-p3En6/oGkFQV55Up8ZPC2oLxvgSxD8CzA0yBrhRZSh3pfv3OFj9aSGVC0yoerAi/O4u7jUVnOGVX1eVFM+0tmQ==",
 			"dev": true,
 			"requires": {
-				"append-transform": "0.4.0"
+				"append-transform": "^0.4.0"
 			}
 		},
 		"istanbul-lib-instrument": {
@@ -7367,13 +7366,13 @@
 			"integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
 			"dev": true,
 			"requires": {
-				"babel-generator": "6.26.1",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0",
-				"babylon": "6.18.0",
-				"istanbul-lib-coverage": "1.2.0",
-				"semver": "5.4.1"
+				"babel-generator": "^6.18.0",
+				"babel-template": "^6.16.0",
+				"babel-traverse": "^6.18.0",
+				"babel-types": "^6.18.0",
+				"babylon": "^6.18.0",
+				"istanbul-lib-coverage": "^1.2.0",
+				"semver": "^5.3.0"
 			}
 		},
 		"istanbul-lib-report": {
@@ -7382,10 +7381,10 @@
 			"integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
 			"dev": true,
 			"requires": {
-				"istanbul-lib-coverage": "1.2.0",
-				"mkdirp": "0.5.1",
-				"path-parse": "1.0.5",
-				"supports-color": "3.2.3"
+				"istanbul-lib-coverage": "^1.2.0",
+				"mkdirp": "^0.5.1",
+				"path-parse": "^1.0.5",
+				"supports-color": "^3.1.2"
 			},
 			"dependencies": {
 				"has-flag": {
@@ -7400,22 +7399,22 @@
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
 		},
 		"istanbul-lib-source-maps": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
-			"integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz",
+			"integrity": "sha512-8O2T/3VhrQHn0XcJbP1/GN7kXMiRAlPi+fj3uEHrjBD8Oz7Py0prSC25C09NuAZS6bgW1NNKAvCSHZXB0irSGA==",
 			"dev": true,
 			"requires": {
-				"debug": "3.1.0",
-				"istanbul-lib-coverage": "1.2.0",
-				"mkdirp": "0.5.1",
-				"rimraf": "2.6.1",
-				"source-map": "0.5.6"
+				"debug": "^3.1.0",
+				"istanbul-lib-coverage": "^1.2.0",
+				"mkdirp": "^0.5.1",
+				"rimraf": "^2.6.1",
+				"source-map": "^0.5.3"
 			},
 			"dependencies": {
 				"debug": {
@@ -7435,17 +7434,17 @@
 			"integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
 			"dev": true,
 			"requires": {
-				"handlebars": "4.0.10"
+				"handlebars": "^4.0.3"
 			}
 		},
 		"jest": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-22.4.3.tgz",
-			"integrity": "sha512-FFCdU/pXOEASfHxFDOWUysI/+FFoqiXJADEIXgDKuZyqSmBD3tZ4BEGH7+M79v7czj7bbkhwtd2LaEDcJiM/GQ==",
+			"version": "23.1.0",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-23.1.0.tgz",
+			"integrity": "sha1-u7f4kxAKEadC3YvQ0EelSwlorRo=",
 			"dev": true,
 			"requires": {
-				"import-local": "1.0.0",
-				"jest-cli": "22.4.3"
+				"import-local": "^1.0.0",
+				"jest-cli": "^23.1.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -7460,8 +7459,14 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.0"
+						"color-convert": "^1.9.0"
 					}
+				},
+				"callsites": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+					"dev": true
 				},
 				"camelcase": {
 					"version": "4.1.0",
@@ -7470,25 +7475,25 @@
 					"dev": true
 				},
 				"chalk": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"cliui": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-					"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"dev": true,
 					"requires": {
-						"string-width": "2.1.1",
-						"strip-ansi": "4.0.0",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
 				"execa": {
@@ -7497,13 +7502,27 @@
 					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					}
+				},
+				"expect": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/expect/-/expect-23.1.0.tgz",
+					"integrity": "sha1-v9/VeiogFw2HWZnul4fMcfAcIF8=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"jest-diff": "^23.0.1",
+						"jest-get-type": "^22.1.0",
+						"jest-matcher-utils": "^23.0.1",
+						"jest-message-util": "^23.1.0",
+						"jest-regex-util": "^23.0.0"
 					}
 				},
 				"has-flag": {
@@ -7513,45 +7532,208 @@
 					"dev": true
 				},
 				"jest-cli": {
-					"version": "22.4.3",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.3.tgz",
-					"integrity": "sha512-IiHybF0DJNqZPsbjn4Cy4vcqcmImpoFwNFnkehzVw8lTUSl4axZh5DHewu5bdpZF2Y5gUqFKYzH0FH4Qx2k+UA==",
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.1.0.tgz",
+					"integrity": "sha1-64vdTODRUlCJLjGtm2m8mdKo9r8=",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "3.1.0",
-						"chalk": "2.3.2",
-						"exit": "0.1.2",
-						"glob": "7.1.2",
-						"graceful-fs": "4.1.11",
-						"import-local": "1.0.0",
-						"is-ci": "1.0.10",
-						"istanbul-api": "1.3.1",
-						"istanbul-lib-coverage": "1.2.0",
-						"istanbul-lib-instrument": "1.10.1",
-						"istanbul-lib-source-maps": "1.2.3",
-						"jest-changed-files": "22.4.3",
-						"jest-config": "22.4.3",
-						"jest-environment-jsdom": "22.4.3",
-						"jest-get-type": "22.4.3",
-						"jest-haste-map": "22.4.3",
-						"jest-message-util": "22.4.3",
-						"jest-regex-util": "22.4.3",
-						"jest-resolve-dependencies": "22.4.3",
-						"jest-runner": "22.4.3",
-						"jest-runtime": "22.4.3",
-						"jest-snapshot": "22.4.3",
-						"jest-util": "22.4.3",
-						"jest-validate": "22.4.3",
-						"jest-worker": "22.4.3",
-						"micromatch": "2.3.11",
-						"node-notifier": "5.2.1",
-						"realpath-native": "1.0.0",
-						"rimraf": "2.6.1",
-						"slash": "1.0.0",
-						"string-length": "2.0.0",
-						"strip-ansi": "4.0.0",
-						"which": "1.3.0",
-						"yargs": "10.1.2"
+						"ansi-escapes": "^3.0.0",
+						"chalk": "^2.0.1",
+						"exit": "^0.1.2",
+						"glob": "^7.1.2",
+						"graceful-fs": "^4.1.11",
+						"import-local": "^1.0.0",
+						"is-ci": "^1.0.10",
+						"istanbul-api": "^1.3.1",
+						"istanbul-lib-coverage": "^1.2.0",
+						"istanbul-lib-instrument": "^1.10.1",
+						"istanbul-lib-source-maps": "^1.2.4",
+						"jest-changed-files": "^23.0.1",
+						"jest-config": "^23.1.0",
+						"jest-environment-jsdom": "^23.1.0",
+						"jest-get-type": "^22.1.0",
+						"jest-haste-map": "^23.1.0",
+						"jest-message-util": "^23.1.0",
+						"jest-regex-util": "^23.0.0",
+						"jest-resolve-dependencies": "^23.0.1",
+						"jest-runner": "^23.1.0",
+						"jest-runtime": "^23.1.0",
+						"jest-snapshot": "^23.0.1",
+						"jest-util": "^23.1.0",
+						"jest-validate": "^23.0.1",
+						"jest-watcher": "^23.1.0",
+						"jest-worker": "^23.0.1",
+						"micromatch": "^2.3.11",
+						"node-notifier": "^5.2.1",
+						"realpath-native": "^1.0.0",
+						"rimraf": "^2.5.4",
+						"slash": "^1.0.0",
+						"string-length": "^2.0.0",
+						"strip-ansi": "^4.0.0",
+						"which": "^1.2.12",
+						"yargs": "^11.0.0"
+					}
+				},
+				"jest-config": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.1.0.tgz",
+					"integrity": "sha1-cIyg9DHTVu5CT7SJXTMIAGvdgkE=",
+					"dev": true,
+					"requires": {
+						"babel-core": "^6.0.0",
+						"babel-jest": "^23.0.1",
+						"chalk": "^2.0.1",
+						"glob": "^7.1.1",
+						"jest-environment-jsdom": "^23.1.0",
+						"jest-environment-node": "^23.1.0",
+						"jest-get-type": "^22.1.0",
+						"jest-jasmine2": "^23.1.0",
+						"jest-regex-util": "^23.0.0",
+						"jest-resolve": "^23.1.0",
+						"jest-util": "^23.1.0",
+						"jest-validate": "^23.0.1",
+						"pretty-format": "^23.0.1"
+					}
+				},
+				"jest-diff": {
+					"version": "23.0.1",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.0.1.tgz",
+					"integrity": "sha1-PUkTfO4SwyCktNK0pvpugtSRoWo=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"diff": "^3.2.0",
+						"jest-get-type": "^22.1.0",
+						"pretty-format": "^23.0.1"
+					}
+				},
+				"jest-environment-jsdom": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.1.0.tgz",
+					"integrity": "sha1-hZKZFOI77TV32sl1X0EG0Gl8R5w=",
+					"dev": true,
+					"requires": {
+						"jest-mock": "^23.1.0",
+						"jest-util": "^23.1.0",
+						"jsdom": "^11.5.1"
+					}
+				},
+				"jest-environment-node": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.1.0.tgz",
+					"integrity": "sha1-RSwL+UnPy7rNoeF2Lu7XC8eEx9U=",
+					"dev": true,
+					"requires": {
+						"jest-mock": "^23.1.0",
+						"jest-util": "^23.1.0"
+					}
+				},
+				"jest-jasmine2": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.1.0.tgz",
+					"integrity": "sha1-SvqzFym2VN3NKwdK3YSTlvE7MLg=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"co": "^4.6.0",
+						"expect": "^23.1.0",
+						"is-generator-fn": "^1.0.0",
+						"jest-diff": "^23.0.1",
+						"jest-each": "^23.1.0",
+						"jest-matcher-utils": "^23.0.1",
+						"jest-message-util": "^23.1.0",
+						"jest-snapshot": "^23.0.1",
+						"jest-util": "^23.1.0",
+						"pretty-format": "^23.0.1"
+					}
+				},
+				"jest-matcher-utils": {
+					"version": "23.0.1",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.0.1.tgz",
+					"integrity": "sha1-DGwNrt+YM8Kn82I2Bp7+y0w/bl8=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"jest-get-type": "^22.1.0",
+						"pretty-format": "^23.0.1"
+					}
+				},
+				"jest-message-util": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.1.0.tgz",
+					"integrity": "sha1-moCbpIfsrFzlEdTmmO47XuJGHqk=",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0-beta.35",
+						"chalk": "^2.0.1",
+						"micromatch": "^2.3.11",
+						"slash": "^1.0.0",
+						"stack-utils": "^1.0.1"
+					}
+				},
+				"jest-mock": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-23.1.0.tgz",
+					"integrity": "sha1-o4HDGxIasfYMRiotrbe4bczKxIc=",
+					"dev": true
+				},
+				"jest-regex-util": {
+					"version": "23.0.0",
+					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.0.0.tgz",
+					"integrity": "sha1-3Vwf3gxG9DcTFM8Q96dRoj9Oj3Y=",
+					"dev": true
+				},
+				"jest-resolve": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.1.0.tgz",
+					"integrity": "sha1-ueMW7s69bwC8UKOWDRUnuuZXktI=",
+					"dev": true,
+					"requires": {
+						"browser-resolve": "^1.11.2",
+						"chalk": "^2.0.1",
+						"realpath-native": "^1.0.0"
+					}
+				},
+				"jest-snapshot": {
+					"version": "23.0.1",
+					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.0.1.tgz",
+					"integrity": "sha1-ZnT6Gbnraamcq+zUFb3cQtavPn4=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"jest-diff": "^23.0.1",
+						"jest-matcher-utils": "^23.0.1",
+						"mkdirp": "^0.5.1",
+						"natural-compare": "^1.4.0",
+						"pretty-format": "^23.0.1"
+					}
+				},
+				"jest-util": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.1.0.tgz",
+					"integrity": "sha1-wCUbrzRkTG3S/qeKli9CY6xVdy0=",
+					"dev": true,
+					"requires": {
+						"callsites": "^2.0.0",
+						"chalk": "^2.0.1",
+						"graceful-fs": "^4.1.11",
+						"is-ci": "^1.0.10",
+						"jest-message-util": "^23.1.0",
+						"mkdirp": "^0.5.1",
+						"slash": "^1.0.0",
+						"source-map": "^0.6.0"
+					}
+				},
+				"jest-validate": {
+					"version": "23.0.1",
+					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.0.1.tgz",
+					"integrity": "sha1-zZ8BqJ0mu4hfEqhmdxXpyGWldU8=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"jest-get-type": "^22.1.0",
+						"leven": "^2.1.0",
+						"pretty-format": "^23.0.1"
 					}
 				},
 				"os-locale": {
@@ -7560,10 +7742,26 @@
 					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 					"dev": true,
 					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
 					}
+				},
+				"pretty-format": {
+					"version": "23.0.1",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.0.1.tgz",
+					"integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0",
+						"ansi-styles": "^3.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
@@ -7571,16 +7769,16 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"supports-color": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				},
 				"which-module": {
@@ -7590,43 +7788,43 @@
 					"dev": true
 				},
 				"yargs": {
-					"version": "10.1.2",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
-					"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+					"version": "11.0.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
+					"integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
 					"dev": true,
 					"requires": {
-						"cliui": "4.0.0",
-						"decamelize": "1.2.0",
-						"find-up": "2.1.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "8.1.0"
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
 					}
 				},
 				"yargs-parser": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-					"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+					"version": "9.0.2",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					}
 				}
 			}
 		},
 		"jest-changed-files": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.4.3.tgz",
-			"integrity": "sha512-83Dh0w1aSkUNFhy5d2dvqWxi/y6weDwVVLU6vmK0cV9VpRxPzhTeGimbsbRDSnEoszhF937M4sDLLeS7Cu/Tmw==",
+			"version": "23.0.1",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-23.0.1.tgz",
+			"integrity": "sha1-95Vy0HIIROpd+EwqRI6GLCJU9gw=",
 			"dev": true,
 			"requires": {
-				"throat": "4.1.0"
+				"throat": "^4.0.0"
 			}
 		},
 		"jest-config": {
@@ -7635,17 +7833,17 @@
 			"integrity": "sha512-KSg3EOToCgkX+lIvenKY7J8s426h6ahXxaUFJxvGoEk0562Z6inWj1TnKoGycTASwiLD+6kSYFALcjdosq9KIQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.2",
-				"glob": "7.1.2",
-				"jest-environment-jsdom": "22.4.3",
-				"jest-environment-node": "22.4.3",
-				"jest-get-type": "22.4.3",
-				"jest-jasmine2": "22.4.3",
-				"jest-regex-util": "22.4.3",
-				"jest-resolve": "22.4.3",
-				"jest-util": "22.4.3",
-				"jest-validate": "22.4.3",
-				"pretty-format": "22.4.3"
+				"chalk": "^2.0.1",
+				"glob": "^7.1.1",
+				"jest-environment-jsdom": "^22.4.3",
+				"jest-environment-node": "^22.4.3",
+				"jest-get-type": "^22.4.3",
+				"jest-jasmine2": "^22.4.3",
+				"jest-regex-util": "^22.4.3",
+				"jest-resolve": "^22.4.3",
+				"jest-util": "^22.4.3",
+				"jest-validate": "^22.4.3",
+				"pretty-format": "^22.4.3"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -7654,7 +7852,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.0"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -7663,9 +7861,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -7680,7 +7878,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -7691,10 +7889,10 @@
 			"integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.2",
-				"diff": "3.3.0",
-				"jest-get-type": "22.4.3",
-				"pretty-format": "22.4.3"
+				"chalk": "^2.0.1",
+				"diff": "^3.2.0",
+				"jest-get-type": "^22.4.3",
+				"pretty-format": "^22.4.3"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -7703,7 +7901,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.0"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -7712,9 +7910,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -7729,18 +7927,81 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
 		},
 		"jest-docblock": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.3.tgz",
-			"integrity": "sha512-uPKBEAw7YrEMcXueMKZXn/rbMxBiSv48fSqy3uEnmgOlQhSX+lthBqHb1fKWNVmFqAp9E/RsSdBfiV31LbzaOg==",
+			"version": "23.0.1",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-23.0.1.tgz",
+			"integrity": "sha1-3t3RgzO+XcJBUmCgTvP86SdrVyU=",
 			"dev": true,
 			"requires": {
-				"detect-newline": "2.1.0"
+				"detect-newline": "^2.1.0"
+			}
+		},
+		"jest-each": {
+			"version": "23.1.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-23.1.0.tgz",
+			"integrity": "sha1-FhRrWSw1SGelrl4TzfFcbGW2lsY=",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.1",
+				"pretty-format": "^23.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "23.0.1",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.0.1.tgz",
+					"integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0",
+						"ansi-styles": "^3.2.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"jest-environment-jsdom": {
@@ -7749,9 +8010,9 @@
 			"integrity": "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
 			"dev": true,
 			"requires": {
-				"jest-mock": "22.4.3",
-				"jest-util": "22.4.3",
-				"jsdom": "11.6.2"
+				"jest-mock": "^22.4.3",
+				"jest-util": "^22.4.3",
+				"jsdom": "^11.5.1"
 			}
 		},
 		"jest-environment-node": {
@@ -7760,8 +8021,8 @@
 			"integrity": "sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==",
 			"dev": true,
 			"requires": {
-				"jest-mock": "22.4.3",
-				"jest-util": "22.4.3"
+				"jest-mock": "^22.4.3",
+				"jest-util": "^22.4.3"
 			}
 		},
 		"jest-get-type": {
@@ -7771,18 +8032,18 @@
 			"dev": true
 		},
 		"jest-haste-map": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.3.tgz",
-			"integrity": "sha512-4Q9fjzuPVwnaqGKDpIsCSoTSnG3cteyk2oNVjBX12HHOaF1oxql+uUiqZb5Ndu7g/vTZfdNwwy4WwYogLh29DQ==",
+			"version": "23.1.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.1.0.tgz",
+			"integrity": "sha1-GObH1ajScTb5G32YUvhd4McHTEk=",
 			"dev": true,
 			"requires": {
-				"fb-watchman": "2.0.0",
-				"graceful-fs": "4.1.11",
-				"jest-docblock": "22.4.3",
-				"jest-serializer": "22.4.3",
-				"jest-worker": "22.4.3",
-				"micromatch": "2.3.11",
-				"sane": "2.5.0"
+				"fb-watchman": "^2.0.0",
+				"graceful-fs": "^4.1.11",
+				"jest-docblock": "^23.0.1",
+				"jest-serializer": "^23.0.1",
+				"jest-worker": "^23.0.1",
+				"micromatch": "^2.3.11",
+				"sane": "^2.0.0"
 			}
 		},
 		"jest-jasmine2": {
@@ -7791,17 +8052,17 @@
 			"integrity": "sha512-yZCPCJUcEY6R5KJB/VReo1AYI2b+5Ky+C+JA1v34jndJsRcLpU4IZX4rFJn7yDTtdNbO/nNqg+3SDIPNH2ecnw==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.2",
-				"co": "4.6.0",
-				"expect": "22.4.3",
-				"graceful-fs": "4.1.11",
-				"is-generator-fn": "1.0.0",
-				"jest-diff": "22.4.3",
-				"jest-matcher-utils": "22.4.3",
-				"jest-message-util": "22.4.3",
-				"jest-snapshot": "22.4.3",
-				"jest-util": "22.4.3",
-				"source-map-support": "0.5.4"
+				"chalk": "^2.0.1",
+				"co": "^4.6.0",
+				"expect": "^22.4.3",
+				"graceful-fs": "^4.1.11",
+				"is-generator-fn": "^1.0.0",
+				"jest-diff": "^22.4.3",
+				"jest-matcher-utils": "^22.4.3",
+				"jest-message-util": "^22.4.3",
+				"jest-snapshot": "^22.4.3",
+				"jest-util": "^22.4.3",
+				"source-map-support": "^0.5.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -7810,7 +8071,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.0"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -7819,9 +8080,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -7842,7 +8103,7 @@
 					"integrity": "sha512-PETSPG6BjY1AHs2t64vS2aqAgu6dMIMXJULWFBGbh2Gr8nVLbCFDo6i/RMMvviIQ2h1Z8+5gQhVKSn2je9nmdg==",
 					"dev": true,
 					"requires": {
-						"source-map": "0.6.1"
+						"source-map": "^0.6.0"
 					}
 				},
 				"supports-color": {
@@ -7851,18 +8112,45 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
 		},
 		"jest-leak-detector": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz",
-			"integrity": "sha512-NZpR/Ls7+ndO57LuXROdgCGz2RmUdC541tTImL9bdUtU3WadgFGm0yV+Ok4Fuia/1rLAn5KaJ+i76L6e3zGJYQ==",
+			"version": "23.0.1",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.0.1.tgz",
+			"integrity": "sha1-nboHUFrDSVw50+wJrB5WRZnoYaA=",
 			"dev": true,
 			"requires": {
-				"pretty-format": "22.4.3"
+				"pretty-format": "^23.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"pretty-format": {
+					"version": "23.0.1",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.0.1.tgz",
+					"integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0",
+						"ansi-styles": "^3.2.0"
+					}
+				}
 			}
 		},
 		"jest-matcher-utils": {
@@ -7871,9 +8159,9 @@
 			"integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.2",
-				"jest-get-type": "22.4.3",
-				"pretty-format": "22.4.3"
+				"chalk": "^2.0.1",
+				"jest-get-type": "^22.4.3",
+				"pretty-format": "^22.4.3"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -7882,7 +8170,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.0"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -7891,9 +8179,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -7908,7 +8196,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -7919,11 +8207,11 @@
 			"integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.42",
-				"chalk": "2.3.2",
-				"micromatch": "2.3.11",
-				"slash": "1.0.0",
-				"stack-utils": "1.0.1"
+				"@babel/code-frame": "^7.0.0-beta.35",
+				"chalk": "^2.0.1",
+				"micromatch": "^2.3.11",
+				"slash": "^1.0.0",
+				"stack-utils": "^1.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -7932,7 +8220,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.0"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -7941,9 +8229,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -7958,7 +8246,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -7981,8 +8269,8 @@
 			"integrity": "sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
 			"dev": true,
 			"requires": {
-				"browser-resolve": "1.11.2",
-				"chalk": "2.3.2"
+				"browser-resolve": "^1.11.2",
+				"chalk": "^2.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -7991,7 +8279,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.0"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -8000,9 +8288,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -8017,65 +8305,19 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
 		},
 		"jest-resolve-dependencies": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz",
-			"integrity": "sha512-06czCMVToSN8F2U4EvgSB1Bv/56gc7MpCftZ9z9fBgUQM7dzHGCMBsyfVA6dZTx8v0FDcnALf7hupeQxaBCvpA==",
+			"version": "23.0.1",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.0.1.tgz",
+			"integrity": "sha1-0BoQ3a2RUsTOzfXqwriFccS2pk0=",
 			"dev": true,
 			"requires": {
-				"jest-regex-util": "22.4.3"
-			}
-		},
-		"jest-runner": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.3.tgz",
-			"integrity": "sha512-U7PLlQPRlWNbvOHWOrrVay9sqhBJmiKeAdKIkvX4n1G2tsvzLlf77nBD28GL1N6tGv4RmuTfI8R8JrkvCa+IBg==",
-			"dev": true,
-			"requires": {
-				"exit": "0.1.2",
-				"jest-config": "22.4.3",
-				"jest-docblock": "22.4.3",
-				"jest-haste-map": "22.4.3",
-				"jest-jasmine2": "22.4.3",
-				"jest-leak-detector": "22.4.3",
-				"jest-message-util": "22.4.3",
-				"jest-runtime": "22.4.3",
-				"jest-util": "22.4.3",
-				"jest-worker": "22.4.3",
-				"throat": "4.1.0"
-			}
-		},
-		"jest-runtime": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.3.tgz",
-			"integrity": "sha512-Eat/esQjevhx9BgJEC8udye+FfoJ2qvxAZfOAWshYGS22HydHn5BgsvPdTtt9cp0fSl5LxYOFA1Pja9Iz2Zt8g==",
-			"dev": true,
-			"requires": {
-				"babel-core": "6.26.0",
-				"babel-jest": "22.4.3",
-				"babel-plugin-istanbul": "4.1.5",
-				"chalk": "2.3.2",
-				"convert-source-map": "1.5.0",
-				"exit": "0.1.2",
-				"graceful-fs": "4.1.11",
-				"jest-config": "22.4.3",
-				"jest-haste-map": "22.4.3",
-				"jest-regex-util": "22.4.3",
-				"jest-resolve": "22.4.3",
-				"jest-util": "22.4.3",
-				"jest-validate": "22.4.3",
-				"json-stable-stringify": "1.0.1",
-				"micromatch": "2.3.11",
-				"realpath-native": "1.0.0",
-				"slash": "1.0.0",
-				"strip-bom": "3.0.0",
-				"write-file-atomic": "2.3.0",
-				"yargs": "10.1.2"
+				"jest-regex-util": "^23.0.0",
+				"jest-snapshot": "^23.0.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -8090,50 +8332,18 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.0"
+						"color-convert": "^1.9.0"
 					}
-				},
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
 				},
 				"chalk": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
-					}
-				},
-				"cliui": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-					"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
-					"dev": true,
-					"requires": {
-						"string-width": "2.1.1",
-						"strip-ansi": "4.0.0",
-						"wrap-ansi": "2.1.0"
-					}
-				},
-				"execa": {
-					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-					"dev": true,
-					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -8142,16 +8352,643 @@
 					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 					"dev": true
 				},
+				"jest-diff": {
+					"version": "23.0.1",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.0.1.tgz",
+					"integrity": "sha1-PUkTfO4SwyCktNK0pvpugtSRoWo=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"diff": "^3.2.0",
+						"jest-get-type": "^22.1.0",
+						"pretty-format": "^23.0.1"
+					}
+				},
+				"jest-matcher-utils": {
+					"version": "23.0.1",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.0.1.tgz",
+					"integrity": "sha1-DGwNrt+YM8Kn82I2Bp7+y0w/bl8=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"jest-get-type": "^22.1.0",
+						"pretty-format": "^23.0.1"
+					}
+				},
+				"jest-regex-util": {
+					"version": "23.0.0",
+					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.0.0.tgz",
+					"integrity": "sha1-3Vwf3gxG9DcTFM8Q96dRoj9Oj3Y=",
+					"dev": true
+				},
+				"jest-snapshot": {
+					"version": "23.0.1",
+					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.0.1.tgz",
+					"integrity": "sha1-ZnT6Gbnraamcq+zUFb3cQtavPn4=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"jest-diff": "^23.0.1",
+						"jest-matcher-utils": "^23.0.1",
+						"mkdirp": "^0.5.1",
+						"natural-compare": "^1.4.0",
+						"pretty-format": "^23.0.1"
+					}
+				},
+				"pretty-format": {
+					"version": "23.0.1",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.0.1.tgz",
+					"integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0",
+						"ansi-styles": "^3.2.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"jest-runner": {
+			"version": "23.1.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.1.0.tgz",
+			"integrity": "sha1-+iCpM//3MaVDKzVh5/ZCZZT6KbU=",
+			"dev": true,
+			"requires": {
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.1.11",
+				"jest-config": "^23.1.0",
+				"jest-docblock": "^23.0.1",
+				"jest-haste-map": "^23.1.0",
+				"jest-jasmine2": "^23.1.0",
+				"jest-leak-detector": "^23.0.1",
+				"jest-message-util": "^23.1.0",
+				"jest-runtime": "^23.1.0",
+				"jest-util": "^23.1.0",
+				"jest-worker": "^23.0.1",
+				"source-map-support": "^0.5.6",
+				"throat": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"callsites": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"expect": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/expect/-/expect-23.1.0.tgz",
+					"integrity": "sha1-v9/VeiogFw2HWZnul4fMcfAcIF8=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"jest-diff": "^23.0.1",
+						"jest-get-type": "^22.1.0",
+						"jest-matcher-utils": "^23.0.1",
+						"jest-message-util": "^23.1.0",
+						"jest-regex-util": "^23.0.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"jest-config": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.1.0.tgz",
+					"integrity": "sha1-cIyg9DHTVu5CT7SJXTMIAGvdgkE=",
+					"dev": true,
+					"requires": {
+						"babel-core": "^6.0.0",
+						"babel-jest": "^23.0.1",
+						"chalk": "^2.0.1",
+						"glob": "^7.1.1",
+						"jest-environment-jsdom": "^23.1.0",
+						"jest-environment-node": "^23.1.0",
+						"jest-get-type": "^22.1.0",
+						"jest-jasmine2": "^23.1.0",
+						"jest-regex-util": "^23.0.0",
+						"jest-resolve": "^23.1.0",
+						"jest-util": "^23.1.0",
+						"jest-validate": "^23.0.1",
+						"pretty-format": "^23.0.1"
+					}
+				},
+				"jest-diff": {
+					"version": "23.0.1",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.0.1.tgz",
+					"integrity": "sha1-PUkTfO4SwyCktNK0pvpugtSRoWo=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"diff": "^3.2.0",
+						"jest-get-type": "^22.1.0",
+						"pretty-format": "^23.0.1"
+					}
+				},
+				"jest-environment-jsdom": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.1.0.tgz",
+					"integrity": "sha1-hZKZFOI77TV32sl1X0EG0Gl8R5w=",
+					"dev": true,
+					"requires": {
+						"jest-mock": "^23.1.0",
+						"jest-util": "^23.1.0",
+						"jsdom": "^11.5.1"
+					}
+				},
+				"jest-environment-node": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.1.0.tgz",
+					"integrity": "sha1-RSwL+UnPy7rNoeF2Lu7XC8eEx9U=",
+					"dev": true,
+					"requires": {
+						"jest-mock": "^23.1.0",
+						"jest-util": "^23.1.0"
+					}
+				},
+				"jest-jasmine2": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.1.0.tgz",
+					"integrity": "sha1-SvqzFym2VN3NKwdK3YSTlvE7MLg=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"co": "^4.6.0",
+						"expect": "^23.1.0",
+						"is-generator-fn": "^1.0.0",
+						"jest-diff": "^23.0.1",
+						"jest-each": "^23.1.0",
+						"jest-matcher-utils": "^23.0.1",
+						"jest-message-util": "^23.1.0",
+						"jest-snapshot": "^23.0.1",
+						"jest-util": "^23.1.0",
+						"pretty-format": "^23.0.1"
+					}
+				},
+				"jest-matcher-utils": {
+					"version": "23.0.1",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.0.1.tgz",
+					"integrity": "sha1-DGwNrt+YM8Kn82I2Bp7+y0w/bl8=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"jest-get-type": "^22.1.0",
+						"pretty-format": "^23.0.1"
+					}
+				},
+				"jest-message-util": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.1.0.tgz",
+					"integrity": "sha1-moCbpIfsrFzlEdTmmO47XuJGHqk=",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0-beta.35",
+						"chalk": "^2.0.1",
+						"micromatch": "^2.3.11",
+						"slash": "^1.0.0",
+						"stack-utils": "^1.0.1"
+					}
+				},
+				"jest-mock": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-23.1.0.tgz",
+					"integrity": "sha1-o4HDGxIasfYMRiotrbe4bczKxIc=",
+					"dev": true
+				},
+				"jest-regex-util": {
+					"version": "23.0.0",
+					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.0.0.tgz",
+					"integrity": "sha1-3Vwf3gxG9DcTFM8Q96dRoj9Oj3Y=",
+					"dev": true
+				},
+				"jest-resolve": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.1.0.tgz",
+					"integrity": "sha1-ueMW7s69bwC8UKOWDRUnuuZXktI=",
+					"dev": true,
+					"requires": {
+						"browser-resolve": "^1.11.2",
+						"chalk": "^2.0.1",
+						"realpath-native": "^1.0.0"
+					}
+				},
+				"jest-snapshot": {
+					"version": "23.0.1",
+					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.0.1.tgz",
+					"integrity": "sha1-ZnT6Gbnraamcq+zUFb3cQtavPn4=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"jest-diff": "^23.0.1",
+						"jest-matcher-utils": "^23.0.1",
+						"mkdirp": "^0.5.1",
+						"natural-compare": "^1.4.0",
+						"pretty-format": "^23.0.1"
+					}
+				},
+				"jest-util": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.1.0.tgz",
+					"integrity": "sha1-wCUbrzRkTG3S/qeKli9CY6xVdy0=",
+					"dev": true,
+					"requires": {
+						"callsites": "^2.0.0",
+						"chalk": "^2.0.1",
+						"graceful-fs": "^4.1.11",
+						"is-ci": "^1.0.10",
+						"jest-message-util": "^23.1.0",
+						"mkdirp": "^0.5.1",
+						"slash": "^1.0.0",
+						"source-map": "^0.6.0"
+					}
+				},
+				"jest-validate": {
+					"version": "23.0.1",
+					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.0.1.tgz",
+					"integrity": "sha1-zZ8BqJ0mu4hfEqhmdxXpyGWldU8=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"jest-get-type": "^22.1.0",
+						"leven": "^2.1.0",
+						"pretty-format": "^23.0.1"
+					}
+				},
+				"pretty-format": {
+					"version": "23.0.1",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.0.1.tgz",
+					"integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0",
+						"ansi-styles": "^3.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"source-map-support": {
+					"version": "0.5.6",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+					"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+					"dev": true,
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"source-map": "^0.6.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"jest-runtime": {
+			"version": "23.1.0",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.1.0.tgz",
+			"integrity": "sha1-tK4OhyWeys/UqIS2OdsHz03WIK8=",
+			"dev": true,
+			"requires": {
+				"babel-core": "^6.0.0",
+				"babel-plugin-istanbul": "^4.1.6",
+				"chalk": "^2.0.1",
+				"convert-source-map": "^1.4.0",
+				"exit": "^0.1.2",
+				"fast-json-stable-stringify": "^2.0.0",
+				"graceful-fs": "^4.1.11",
+				"jest-config": "^23.1.0",
+				"jest-haste-map": "^23.1.0",
+				"jest-message-util": "^23.1.0",
+				"jest-regex-util": "^23.0.0",
+				"jest-resolve": "^23.1.0",
+				"jest-snapshot": "^23.0.1",
+				"jest-util": "^23.1.0",
+				"jest-validate": "^23.0.1",
+				"micromatch": "^2.3.11",
+				"realpath-native": "^1.0.0",
+				"slash": "^1.0.0",
+				"strip-bom": "3.0.0",
+				"write-file-atomic": "^2.1.0",
+				"yargs": "^11.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"callsites": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+					"dev": true
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"cliui": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+					"dev": true,
+					"requires": {
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
+						"wrap-ansi": "^2.0.0"
+					}
+				},
+				"execa": {
+					"version": "0.7.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					}
+				},
+				"expect": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/expect/-/expect-23.1.0.tgz",
+					"integrity": "sha1-v9/VeiogFw2HWZnul4fMcfAcIF8=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"jest-diff": "^23.0.1",
+						"jest-get-type": "^22.1.0",
+						"jest-matcher-utils": "^23.0.1",
+						"jest-message-util": "^23.1.0",
+						"jest-regex-util": "^23.0.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"jest-config": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.1.0.tgz",
+					"integrity": "sha1-cIyg9DHTVu5CT7SJXTMIAGvdgkE=",
+					"dev": true,
+					"requires": {
+						"babel-core": "^6.0.0",
+						"babel-jest": "^23.0.1",
+						"chalk": "^2.0.1",
+						"glob": "^7.1.1",
+						"jest-environment-jsdom": "^23.1.0",
+						"jest-environment-node": "^23.1.0",
+						"jest-get-type": "^22.1.0",
+						"jest-jasmine2": "^23.1.0",
+						"jest-regex-util": "^23.0.0",
+						"jest-resolve": "^23.1.0",
+						"jest-util": "^23.1.0",
+						"jest-validate": "^23.0.1",
+						"pretty-format": "^23.0.1"
+					}
+				},
+				"jest-diff": {
+					"version": "23.0.1",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.0.1.tgz",
+					"integrity": "sha1-PUkTfO4SwyCktNK0pvpugtSRoWo=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"diff": "^3.2.0",
+						"jest-get-type": "^22.1.0",
+						"pretty-format": "^23.0.1"
+					}
+				},
+				"jest-environment-jsdom": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.1.0.tgz",
+					"integrity": "sha1-hZKZFOI77TV32sl1X0EG0Gl8R5w=",
+					"dev": true,
+					"requires": {
+						"jest-mock": "^23.1.0",
+						"jest-util": "^23.1.0",
+						"jsdom": "^11.5.1"
+					}
+				},
+				"jest-environment-node": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.1.0.tgz",
+					"integrity": "sha1-RSwL+UnPy7rNoeF2Lu7XC8eEx9U=",
+					"dev": true,
+					"requires": {
+						"jest-mock": "^23.1.0",
+						"jest-util": "^23.1.0"
+					}
+				},
+				"jest-jasmine2": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.1.0.tgz",
+					"integrity": "sha1-SvqzFym2VN3NKwdK3YSTlvE7MLg=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"co": "^4.6.0",
+						"expect": "^23.1.0",
+						"is-generator-fn": "^1.0.0",
+						"jest-diff": "^23.0.1",
+						"jest-each": "^23.1.0",
+						"jest-matcher-utils": "^23.0.1",
+						"jest-message-util": "^23.1.0",
+						"jest-snapshot": "^23.0.1",
+						"jest-util": "^23.1.0",
+						"pretty-format": "^23.0.1"
+					}
+				},
+				"jest-matcher-utils": {
+					"version": "23.0.1",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.0.1.tgz",
+					"integrity": "sha1-DGwNrt+YM8Kn82I2Bp7+y0w/bl8=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"jest-get-type": "^22.1.0",
+						"pretty-format": "^23.0.1"
+					}
+				},
+				"jest-message-util": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.1.0.tgz",
+					"integrity": "sha1-moCbpIfsrFzlEdTmmO47XuJGHqk=",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0-beta.35",
+						"chalk": "^2.0.1",
+						"micromatch": "^2.3.11",
+						"slash": "^1.0.0",
+						"stack-utils": "^1.0.1"
+					}
+				},
+				"jest-mock": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-23.1.0.tgz",
+					"integrity": "sha1-o4HDGxIasfYMRiotrbe4bczKxIc=",
+					"dev": true
+				},
+				"jest-regex-util": {
+					"version": "23.0.0",
+					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.0.0.tgz",
+					"integrity": "sha1-3Vwf3gxG9DcTFM8Q96dRoj9Oj3Y=",
+					"dev": true
+				},
+				"jest-resolve": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.1.0.tgz",
+					"integrity": "sha1-ueMW7s69bwC8UKOWDRUnuuZXktI=",
+					"dev": true,
+					"requires": {
+						"browser-resolve": "^1.11.2",
+						"chalk": "^2.0.1",
+						"realpath-native": "^1.0.0"
+					}
+				},
+				"jest-snapshot": {
+					"version": "23.0.1",
+					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.0.1.tgz",
+					"integrity": "sha1-ZnT6Gbnraamcq+zUFb3cQtavPn4=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"jest-diff": "^23.0.1",
+						"jest-matcher-utils": "^23.0.1",
+						"mkdirp": "^0.5.1",
+						"natural-compare": "^1.4.0",
+						"pretty-format": "^23.0.1"
+					}
+				},
+				"jest-util": {
+					"version": "23.1.0",
+					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.1.0.tgz",
+					"integrity": "sha1-wCUbrzRkTG3S/qeKli9CY6xVdy0=",
+					"dev": true,
+					"requires": {
+						"callsites": "^2.0.0",
+						"chalk": "^2.0.1",
+						"graceful-fs": "^4.1.11",
+						"is-ci": "^1.0.10",
+						"jest-message-util": "^23.1.0",
+						"mkdirp": "^0.5.1",
+						"slash": "^1.0.0",
+						"source-map": "^0.6.0"
+					}
+				},
+				"jest-validate": {
+					"version": "23.0.1",
+					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.0.1.tgz",
+					"integrity": "sha1-zZ8BqJ0mu4hfEqhmdxXpyGWldU8=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"jest-get-type": "^22.1.0",
+						"leven": "^2.1.0",
+						"pretty-format": "^23.0.1"
+					}
+				},
 				"os-locale": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
 					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 					"dev": true,
 					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
 					}
+				},
+				"pretty-format": {
+					"version": "23.0.1",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.0.1.tgz",
+					"integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0",
+						"ansi-styles": "^3.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
@@ -8159,7 +8996,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"strip-bom": {
@@ -8169,12 +9006,12 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				},
 				"which-module": {
@@ -8184,40 +9021,40 @@
 					"dev": true
 				},
 				"yargs": {
-					"version": "10.1.2",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
-					"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+					"version": "11.0.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
+					"integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
 					"dev": true,
 					"requires": {
-						"cliui": "4.0.0",
-						"decamelize": "1.2.0",
-						"find-up": "2.1.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "8.1.0"
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
 					}
 				},
 				"yargs-parser": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-					"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+					"version": "9.0.2",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					}
 				}
 			}
 		},
 		"jest-serializer": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-22.4.3.tgz",
-			"integrity": "sha512-uPaUAppx4VUfJ0QDerpNdF43F68eqKWCzzhUlKNDsUPhjOon7ZehR4C809GCqh765FoMRtTVUVnGvIoskkYHiw==",
+			"version": "23.0.1",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-23.0.1.tgz",
+			"integrity": "sha1-o3dq6zEekP6D+rnlM+hRAr0WQWU=",
 			"dev": true
 		},
 		"jest-snapshot": {
@@ -8226,12 +9063,12 @@
 			"integrity": "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.2",
-				"jest-diff": "22.4.3",
-				"jest-matcher-utils": "22.4.3",
-				"mkdirp": "0.5.1",
-				"natural-compare": "1.4.0",
-				"pretty-format": "22.4.3"
+				"chalk": "^2.0.1",
+				"jest-diff": "^22.4.3",
+				"jest-matcher-utils": "^22.4.3",
+				"mkdirp": "^0.5.1",
+				"natural-compare": "^1.4.0",
+				"pretty-format": "^22.4.3"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8240,7 +9077,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.0"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -8249,9 +9086,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -8266,7 +9103,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -8277,13 +9114,13 @@
 			"integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
 			"dev": true,
 			"requires": {
-				"callsites": "2.0.0",
-				"chalk": "2.3.2",
-				"graceful-fs": "4.1.11",
-				"is-ci": "1.0.10",
-				"jest-message-util": "22.4.3",
-				"mkdirp": "0.5.1",
-				"source-map": "0.6.1"
+				"callsites": "^2.0.0",
+				"chalk": "^2.0.1",
+				"graceful-fs": "^4.1.11",
+				"is-ci": "^1.0.10",
+				"jest-message-util": "^22.4.3",
+				"mkdirp": "^0.5.1",
+				"source-map": "^0.6.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8292,7 +9129,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.0"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"callsites": {
@@ -8307,9 +9144,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -8330,7 +9167,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -8341,11 +9178,11 @@
 			"integrity": "sha512-CfFM18W3GSP/xgmA4UouIx0ljdtfD2mjeBC6c89Gg17E44D4tQhAcTrZmf9djvipwU30kSTnk6CzcxdCCeSXfA==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.2",
-				"jest-config": "22.4.3",
-				"jest-get-type": "22.4.3",
-				"leven": "2.1.0",
-				"pretty-format": "22.4.3"
+				"chalk": "^2.0.1",
+				"jest-config": "^22.4.3",
+				"jest-get-type": "^22.4.3",
+				"leven": "^2.1.0",
+				"pretty-format": "^22.4.3"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8354,7 +9191,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.0"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -8363,9 +9200,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -8380,18 +9217,66 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"jest-watcher": {
+			"version": "23.1.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-23.1.0.tgz",
+			"integrity": "sha1-qNWELjjZ+0r/+CPfartCpYrmzb0=",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.1",
+				"string-length": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
 		},
 		"jest-worker": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.4.3.tgz",
-			"integrity": "sha512-B1ucW4fI8qVAuZmicFxI1R3kr2fNeYJyvIQ1rKcuLYnenFV5K5aMbxFj6J0i00Ju83S8jP2d7Dz14+AvbIHRYQ==",
+			"version": "23.0.1",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-23.0.1.tgz",
+			"integrity": "sha1-nmSd2WP/QEYCb5HEAX8Dmmqkp7w=",
 			"dev": true,
 			"requires": {
-				"merge-stream": "1.0.1"
+				"merge-stream": "^1.0.1"
 			}
 		},
 		"js-tokens": {
@@ -8406,8 +9291,8 @@
 			"integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
 			"dev": true,
 			"requires": {
-				"argparse": "1.0.9",
-				"esprima": "4.0.0"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			}
 		},
 		"jsbn": {
@@ -8423,32 +9308,32 @@
 			"integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
 			"dev": true,
 			"requires": {
-				"abab": "1.0.4",
-				"acorn": "5.5.3",
-				"acorn-globals": "4.1.0",
-				"array-equal": "1.0.0",
-				"browser-process-hrtime": "0.1.2",
-				"content-type-parser": "1.0.2",
-				"cssom": "0.3.2",
-				"cssstyle": "0.2.37",
-				"domexception": "1.0.1",
-				"escodegen": "1.9.1",
-				"html-encoding-sniffer": "1.0.2",
-				"left-pad": "1.2.0",
-				"nwmatcher": "1.4.4",
+				"abab": "^1.0.4",
+				"acorn": "^5.3.0",
+				"acorn-globals": "^4.1.0",
+				"array-equal": "^1.0.0",
+				"browser-process-hrtime": "^0.1.2",
+				"content-type-parser": "^1.0.2",
+				"cssom": ">= 0.3.2 < 0.4.0",
+				"cssstyle": ">= 0.2.37 < 0.3.0",
+				"domexception": "^1.0.0",
+				"escodegen": "^1.9.0",
+				"html-encoding-sniffer": "^1.0.2",
+				"left-pad": "^1.2.0",
+				"nwmatcher": "^1.4.3",
 				"parse5": "4.0.0",
-				"pn": "1.1.0",
-				"request": "2.85.0",
-				"request-promise-native": "1.0.5",
-				"sax": "1.2.4",
-				"symbol-tree": "3.2.2",
-				"tough-cookie": "2.3.4",
-				"w3c-hr-time": "1.0.1",
-				"webidl-conversions": "4.0.2",
-				"whatwg-encoding": "1.0.3",
-				"whatwg-url": "6.4.0",
-				"ws": "4.1.0",
-				"xml-name-validator": "3.0.0"
+				"pn": "^1.1.0",
+				"request": "^2.83.0",
+				"request-promise-native": "^1.0.5",
+				"sax": "^1.2.4",
+				"symbol-tree": "^3.2.2",
+				"tough-cookie": "^2.3.3",
+				"w3c-hr-time": "^1.0.1",
+				"webidl-conversions": "^4.0.2",
+				"whatwg-encoding": "^1.0.3",
+				"whatwg-url": "^6.4.0",
+				"ws": "^4.0.0",
+				"xml-name-validator": "^3.0.0"
 			},
 			"dependencies": {
 				"acorn": {
@@ -8507,7 +9392,7 @@
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
 			"dev": true,
 			"requires": {
-				"jsonify": "0.0.0"
+				"jsonify": "~0.0.0"
 			}
 		},
 		"json-stable-stringify-without-jsonify": {
@@ -8540,7 +9425,7 @@
 			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11"
+				"graceful-fs": "^4.1.6"
 			}
 		},
 		"jsonify": {
@@ -8581,7 +9466,7 @@
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"dev": true,
 			"requires": {
-				"is-buffer": "1.1.5"
+				"is-buffer": "^1.1.5"
 			}
 		},
 		"lazy-cache": {
@@ -8596,7 +9481,7 @@
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 			"dev": true,
 			"requires": {
-				"invert-kv": "1.0.0"
+				"invert-kv": "^1.0.0"
 			}
 		},
 		"left-pad": {
@@ -8611,45 +9496,45 @@
 			"integrity": "sha512-8KvXqRsnkqkorOlE7tMnaDl8b43t8i6/ZyGthoyIzb7ikeH2XNrQOHuI1FWsuOtP2HY3vLp2zuMvM5Zuw3ulUA==",
 			"dev": true,
 			"requires": {
-				"async": "1.5.2",
-				"chalk": "2.3.2",
-				"cmd-shim": "2.0.2",
-				"columnify": "1.5.4",
-				"command-join": "2.0.0",
-				"conventional-changelog-cli": "1.3.20",
-				"conventional-recommended-bump": "1.2.1",
-				"dedent": "0.7.0",
-				"execa": "0.8.0",
-				"find-up": "2.1.0",
-				"fs-extra": "4.0.3",
-				"get-port": "3.2.0",
-				"glob": "7.1.2",
-				"glob-parent": "3.1.0",
-				"globby": "6.1.0",
-				"graceful-fs": "4.1.11",
-				"hosted-git-info": "2.5.0",
-				"inquirer": "3.3.0",
-				"is-ci": "1.0.10",
-				"load-json-file": "4.0.0",
-				"lodash": "4.17.5",
-				"minimatch": "3.0.4",
-				"npmlog": "4.1.2",
-				"p-finally": "1.0.0",
-				"package-json": "4.0.1",
-				"path-exists": "3.0.0",
-				"read-cmd-shim": "1.0.1",
-				"read-pkg": "3.0.0",
-				"rimraf": "2.6.1",
-				"safe-buffer": "5.1.1",
-				"semver": "5.4.1",
-				"signal-exit": "3.0.2",
-				"slash": "1.0.0",
-				"strong-log-transformer": "1.0.6",
-				"temp-write": "3.4.0",
-				"write-file-atomic": "2.3.0",
-				"write-json-file": "2.3.0",
-				"write-pkg": "3.1.0",
-				"yargs": "8.0.2"
+				"async": "^1.5.0",
+				"chalk": "^2.1.0",
+				"cmd-shim": "^2.0.2",
+				"columnify": "^1.5.4",
+				"command-join": "^2.0.0",
+				"conventional-changelog-cli": "^1.3.13",
+				"conventional-recommended-bump": "^1.2.1",
+				"dedent": "^0.7.0",
+				"execa": "^0.8.0",
+				"find-up": "^2.1.0",
+				"fs-extra": "^4.0.1",
+				"get-port": "^3.2.0",
+				"glob": "^7.1.2",
+				"glob-parent": "^3.1.0",
+				"globby": "^6.1.0",
+				"graceful-fs": "^4.1.11",
+				"hosted-git-info": "^2.5.0",
+				"inquirer": "^3.2.2",
+				"is-ci": "^1.0.10",
+				"load-json-file": "^4.0.0",
+				"lodash": "^4.17.4",
+				"minimatch": "^3.0.4",
+				"npmlog": "^4.1.2",
+				"p-finally": "^1.0.0",
+				"package-json": "^4.0.1",
+				"path-exists": "^3.0.0",
+				"read-cmd-shim": "^1.0.1",
+				"read-pkg": "^3.0.0",
+				"rimraf": "^2.6.1",
+				"safe-buffer": "^5.1.1",
+				"semver": "^5.4.1",
+				"signal-exit": "^3.0.2",
+				"slash": "^1.0.0",
+				"strong-log-transformer": "^1.0.6",
+				"temp-write": "^3.3.0",
+				"write-file-atomic": "^2.3.0",
+				"write-json-file": "^2.2.0",
+				"write-pkg": "^3.1.0",
+				"yargs": "^8.0.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8658,7 +9543,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.0"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"async": {
@@ -8679,9 +9564,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"cliui": {
@@ -8690,9 +9575,9 @@
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 					"dev": true,
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wrap-ansi": "^2.0.0"
 					},
 					"dependencies": {
 						"string-width": {
@@ -8701,9 +9586,9 @@
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"dev": true,
 							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
 							}
 						}
 					}
@@ -8714,8 +9599,8 @@
 					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 					"dev": true,
 					"requires": {
-						"is-glob": "3.1.0",
-						"path-dirname": "1.0.2"
+						"is-glob": "^3.1.0",
+						"path-dirname": "^1.0.0"
 					}
 				},
 				"has-flag": {
@@ -8736,7 +9621,7 @@
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"is-glob": {
@@ -8745,7 +9630,7 @@
 					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "2.1.1"
+						"is-extglob": "^2.1.0"
 					}
 				},
 				"load-json-file": {
@@ -8754,10 +9639,10 @@
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "4.0.0",
-						"pify": "3.0.0",
-						"strip-bom": "3.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
 					}
 				},
 				"os-locale": {
@@ -8766,9 +9651,9 @@
 					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 					"dev": true,
 					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
 					},
 					"dependencies": {
 						"execa": {
@@ -8777,13 +9662,13 @@
 							"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 							"dev": true,
 							"requires": {
-								"cross-spawn": "5.1.0",
-								"get-stream": "3.0.0",
-								"is-stream": "1.1.0",
-								"npm-run-path": "2.0.2",
-								"p-finally": "1.0.0",
-								"signal-exit": "3.0.2",
-								"strip-eof": "1.0.0"
+								"cross-spawn": "^5.0.1",
+								"get-stream": "^3.0.0",
+								"is-stream": "^1.1.0",
+								"npm-run-path": "^2.0.0",
+								"p-finally": "^1.0.0",
+								"signal-exit": "^3.0.0",
+								"strip-eof": "^1.0.0"
 							}
 						}
 					}
@@ -8794,8 +9679,8 @@
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 					"dev": true,
 					"requires": {
-						"error-ex": "1.3.1",
-						"json-parse-better-errors": "1.0.1"
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
 					}
 				},
 				"path-type": {
@@ -8804,7 +9689,7 @@
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 					"dev": true,
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"read-pkg": {
@@ -8813,9 +9698,9 @@
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "4.0.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "3.0.0"
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -8824,8 +9709,8 @@
 					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
 					"dev": true,
 					"requires": {
-						"find-up": "2.1.0",
-						"read-pkg": "2.0.0"
+						"find-up": "^2.0.0",
+						"read-pkg": "^2.0.0"
 					},
 					"dependencies": {
 						"load-json-file": {
@@ -8834,10 +9719,10 @@
 							"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
 							"dev": true,
 							"requires": {
-								"graceful-fs": "4.1.11",
-								"parse-json": "2.2.0",
-								"pify": "2.3.0",
-								"strip-bom": "3.0.0"
+								"graceful-fs": "^4.1.2",
+								"parse-json": "^2.2.0",
+								"pify": "^2.0.0",
+								"strip-bom": "^3.0.0"
 							}
 						},
 						"parse-json": {
@@ -8846,7 +9731,7 @@
 							"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 							"dev": true,
 							"requires": {
-								"error-ex": "1.3.1"
+								"error-ex": "^1.2.0"
 							}
 						},
 						"path-type": {
@@ -8855,7 +9740,7 @@
 							"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
 							"dev": true,
 							"requires": {
-								"pify": "2.3.0"
+								"pify": "^2.0.0"
 							}
 						},
 						"pify": {
@@ -8870,9 +9755,9 @@
 							"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
 							"dev": true,
 							"requires": {
-								"load-json-file": "2.0.0",
-								"normalize-package-data": "2.4.0",
-								"path-type": "2.0.0"
+								"load-json-file": "^2.0.0",
+								"normalize-package-data": "^2.3.2",
+								"path-type": "^2.0.0"
 							}
 						}
 					}
@@ -8889,7 +9774,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				},
 				"which-module": {
@@ -8904,19 +9789,19 @@
 					"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"read-pkg-up": "2.0.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "7.0.0"
+						"camelcase": "^4.1.0",
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"read-pkg-up": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^7.0.0"
 					}
 				},
 				"yargs-parser": {
@@ -8925,7 +9810,7 @@
 					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					}
 				}
 			}
@@ -8942,8 +9827,8 @@
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2"
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
 			}
 		},
 		"lint-staged": {
@@ -8952,28 +9837,28 @@
 			"integrity": "sha512-9w4vwNJ1A7o4mwKhz/5B0VateS24KJjeU1ppO2UOBdbTg/iiypF4U6F3yckEms0Fbf5uvfLiPVp9pG2lBbVA6g==",
 			"dev": true,
 			"requires": {
-				"app-root-path": "2.0.1",
-				"chalk": "2.3.2",
-				"commander": "2.15.1",
-				"cosmiconfig": "4.0.0",
-				"debug": "3.1.0",
-				"dedent": "0.7.0",
-				"execa": "0.9.0",
-				"find-parent-dir": "0.3.0",
-				"is-glob": "4.0.0",
-				"jest-validate": "22.4.3",
-				"listr": "0.13.0",
-				"lodash": "4.17.5",
-				"log-symbols": "2.2.0",
-				"micromatch": "3.1.10",
-				"npm-which": "3.0.1",
-				"p-map": "1.1.1",
-				"path-is-inside": "1.0.2",
-				"pify": "3.0.0",
-				"please-upgrade-node": "3.0.1",
+				"app-root-path": "^2.0.1",
+				"chalk": "^2.3.1",
+				"commander": "^2.14.1",
+				"cosmiconfig": "^4.0.0",
+				"debug": "^3.1.0",
+				"dedent": "^0.7.0",
+				"execa": "^0.9.0",
+				"find-parent-dir": "^0.3.0",
+				"is-glob": "^4.0.0",
+				"jest-validate": "^22.4.0",
+				"listr": "^0.13.0",
+				"lodash": "^4.17.5",
+				"log-symbols": "^2.2.0",
+				"micromatch": "^3.1.8",
+				"npm-which": "^3.0.1",
+				"p-map": "^1.1.1",
+				"path-is-inside": "^1.0.2",
+				"pify": "^3.0.0",
+				"please-upgrade-node": "^3.0.1",
 				"staged-git-files": "1.1.1",
-				"string-argv": "0.0.2",
-				"stringify-object": "3.2.2"
+				"string-argv": "^0.0.2",
+				"stringify-object": "^3.2.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8982,7 +9867,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.0"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"arr-diff": {
@@ -9003,16 +9888,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"repeat-element": "1.1.2",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -9021,7 +9906,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -9032,9 +9917,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"debug": {
@@ -9052,13 +9937,13 @@
 					"integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					}
 				},
 				"expand-brackets": {
@@ -9067,13 +9952,13 @@
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"dev": true,
 					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"debug": {
@@ -9091,7 +9976,7 @@
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
@@ -9100,7 +9985,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-descriptor": {
@@ -9109,9 +9994,9 @@
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							}
 						},
 						"kind-of": {
@@ -9128,14 +10013,14 @@
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"dev": true,
 					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -9144,7 +10029,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
@@ -9153,7 +10038,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -9164,10 +10049,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -9176,7 +10061,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -9193,7 +10078,7 @@
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -9202,7 +10087,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -9213,7 +10098,7 @@
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -9222,7 +10107,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -9239,7 +10124,7 @@
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "2.1.1"
+						"is-extglob": "^2.1.1"
 					}
 				},
 				"is-number": {
@@ -9248,7 +10133,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -9257,7 +10142,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -9280,19 +10165,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.9",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					}
 				},
 				"supports-color": {
@@ -9301,7 +10186,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -9312,23 +10197,23 @@
 			"integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
 			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"cli-truncate": "0.2.1",
-				"figures": "1.7.0",
-				"indent-string": "2.1.0",
-				"is-observable": "0.2.0",
-				"is-promise": "2.1.0",
-				"is-stream": "1.1.0",
-				"listr-silent-renderer": "1.1.1",
-				"listr-update-renderer": "0.4.0",
-				"listr-verbose-renderer": "0.4.1",
-				"log-symbols": "1.0.2",
-				"log-update": "1.0.2",
-				"ora": "0.2.3",
-				"p-map": "1.1.1",
-				"rxjs": "5.5.8",
-				"stream-to-observable": "0.2.0",
-				"strip-ansi": "3.0.1"
+				"chalk": "^1.1.3",
+				"cli-truncate": "^0.2.1",
+				"figures": "^1.7.0",
+				"indent-string": "^2.1.0",
+				"is-observable": "^0.2.0",
+				"is-promise": "^2.1.0",
+				"is-stream": "^1.1.0",
+				"listr-silent-renderer": "^1.1.1",
+				"listr-update-renderer": "^0.4.0",
+				"listr-verbose-renderer": "^0.4.0",
+				"log-symbols": "^1.0.2",
+				"log-update": "^1.0.2",
+				"ora": "^0.2.3",
+				"p-map": "^1.1.1",
+				"rxjs": "^5.4.2",
+				"stream-to-observable": "^0.2.0",
+				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
 				"figures": {
@@ -9337,8 +10222,8 @@
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 					"dev": true,
 					"requires": {
-						"escape-string-regexp": "1.0.5",
-						"object-assign": "4.1.1"
+						"escape-string-regexp": "^1.0.5",
+						"object-assign": "^4.1.0"
 					}
 				},
 				"log-symbols": {
@@ -9347,7 +10232,7 @@
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
 					"dev": true,
 					"requires": {
-						"chalk": "1.1.3"
+						"chalk": "^1.0.0"
 					}
 				}
 			}
@@ -9364,14 +10249,14 @@
 			"integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
 			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"cli-truncate": "0.2.1",
-				"elegant-spinner": "1.0.1",
-				"figures": "1.7.0",
-				"indent-string": "3.2.0",
-				"log-symbols": "1.0.2",
-				"log-update": "1.0.2",
-				"strip-ansi": "3.0.1"
+				"chalk": "^1.1.3",
+				"cli-truncate": "^0.2.1",
+				"elegant-spinner": "^1.0.1",
+				"figures": "^1.7.0",
+				"indent-string": "^3.0.0",
+				"log-symbols": "^1.0.2",
+				"log-update": "^1.0.2",
+				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
 				"figures": {
@@ -9380,8 +10265,8 @@
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 					"dev": true,
 					"requires": {
-						"escape-string-regexp": "1.0.5",
-						"object-assign": "4.1.1"
+						"escape-string-regexp": "^1.0.5",
+						"object-assign": "^4.1.0"
 					}
 				},
 				"indent-string": {
@@ -9396,7 +10281,7 @@
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
 					"dev": true,
 					"requires": {
-						"chalk": "1.1.3"
+						"chalk": "^1.0.0"
 					}
 				}
 			}
@@ -9407,10 +10292,10 @@
 			"integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
 			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"cli-cursor": "1.0.2",
-				"date-fns": "1.29.0",
-				"figures": "1.7.0"
+				"chalk": "^1.1.3",
+				"cli-cursor": "^1.0.2",
+				"date-fns": "^1.27.2",
+				"figures": "^1.7.0"
 			},
 			"dependencies": {
 				"cli-cursor": {
@@ -9419,7 +10304,7 @@
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 					"dev": true,
 					"requires": {
-						"restore-cursor": "1.0.1"
+						"restore-cursor": "^1.0.1"
 					}
 				},
 				"figures": {
@@ -9428,13 +10313,13 @@
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 					"dev": true,
 					"requires": {
-						"escape-string-regexp": "1.0.5",
-						"object-assign": "4.1.1"
+						"escape-string-regexp": "^1.0.5",
+						"object-assign": "^4.1.0"
 					}
 				},
 				"onetime": {
 					"version": "1.1.0",
-					"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
 					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
 					"dev": true
 				},
@@ -9444,8 +10329,8 @@
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 					"dev": true,
 					"requires": {
-						"exit-hook": "1.1.1",
-						"onetime": "1.1.0"
+						"exit-hook": "^1.0.0",
+						"onetime": "^1.0.0"
 					}
 				}
 			}
@@ -9456,11 +10341,11 @@
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"parse-json": "2.2.0",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1",
-				"strip-bom": "2.0.0"
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^2.2.0",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0",
+				"strip-bom": "^2.0.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -9483,9 +10368,9 @@
 			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
 			"dev": true,
 			"requires": {
-				"big.js": "3.1.3",
-				"emojis-list": "2.1.0",
-				"json5": "0.5.1"
+				"big.js": "^3.1.3",
+				"emojis-list": "^2.0.0",
+				"json5": "^0.5.0"
 			}
 		},
 		"locate-path": {
@@ -9494,8 +10379,8 @@
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"dev": true,
 			"requires": {
-				"p-locate": "2.0.0",
-				"path-exists": "3.0.0"
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
 			}
 		},
 		"lodash": {
@@ -9600,8 +10485,8 @@
 			"integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
 			"dev": true,
 			"requires": {
-				"lodash._reinterpolate": "3.0.0",
-				"lodash.templatesettings": "4.1.0"
+				"lodash._reinterpolate": "~3.0.0",
+				"lodash.templatesettings": "^4.0.0"
 			}
 		},
 		"lodash.templatesettings": {
@@ -9610,7 +10495,7 @@
 			"integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
 			"dev": true,
 			"requires": {
-				"lodash._reinterpolate": "3.0.0"
+				"lodash._reinterpolate": "~3.0.0"
 			}
 		},
 		"log-symbols": {
@@ -9619,7 +10504,7 @@
 			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.2"
+				"chalk": "^2.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -9628,7 +10513,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.0"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -9637,9 +10522,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -9654,7 +10539,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -9665,8 +10550,8 @@
 			"integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "1.4.0",
-				"cli-cursor": "1.0.2"
+				"ansi-escapes": "^1.0.0",
+				"cli-cursor": "^1.0.2"
 			},
 			"dependencies": {
 				"ansi-escapes": {
@@ -9681,12 +10566,12 @@
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 					"dev": true,
 					"requires": {
-						"restore-cursor": "1.0.1"
+						"restore-cursor": "^1.0.1"
 					}
 				},
 				"onetime": {
 					"version": "1.1.0",
-					"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
 					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
 					"dev": true
 				},
@@ -9696,8 +10581,8 @@
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 					"dev": true,
 					"requires": {
-						"exit-hook": "1.1.1",
-						"onetime": "1.1.0"
+						"exit-hook": "^1.0.0",
+						"onetime": "^1.0.0"
 					}
 				}
 			}
@@ -9720,7 +10605,7 @@
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
 			"dev": true,
 			"requires": {
-				"js-tokens": "3.0.2"
+				"js-tokens": "^3.0.0"
 			}
 		},
 		"loud-rejection": {
@@ -9729,8 +10614,8 @@
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
 			"dev": true,
 			"requires": {
-				"currently-unhandled": "0.4.1",
-				"signal-exit": "3.0.2"
+				"currently-unhandled": "^0.4.1",
+				"signal-exit": "^3.0.0"
 			}
 		},
 		"lowercase-keys": {
@@ -9745,8 +10630,8 @@
 			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
 			"dev": true,
 			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
 			}
 		},
 		"magic-string": {
@@ -9755,7 +10640,7 @@
 			"integrity": "sha1-lw67DacZMwEoX7GqZQ85vdgetFo=",
 			"dev": true,
 			"requires": {
-				"vlq": "0.2.3"
+				"vlq": "^0.2.1"
 			}
 		},
 		"make-dir": {
@@ -9764,7 +10649,7 @@
 			"integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
 			"dev": true,
 			"requires": {
-				"pify": "3.0.0"
+				"pify": "^3.0.0"
 			}
 		},
 		"makeerror": {
@@ -9773,7 +10658,7 @@
 			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
 			"dev": true,
 			"requires": {
-				"tmpl": "1.0.4"
+				"tmpl": "1.0.x"
 			}
 		},
 		"map-cache": {
@@ -9794,7 +10679,7 @@
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
 			"dev": true,
 			"requires": {
-				"object-visit": "1.0.1"
+				"object-visit": "^1.0.0"
 			}
 		},
 		"mdn-data": {
@@ -9815,7 +10700,7 @@
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "1.1.0"
+				"mimic-fn": "^1.0.0"
 			}
 		},
 		"memory-fs": {
@@ -9824,8 +10709,8 @@
 			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
 			"dev": true,
 			"requires": {
-				"errno": "0.1.4",
-				"readable-stream": "2.3.3"
+				"errno": "^0.1.3",
+				"readable-stream": "^2.0.1"
 			}
 		},
 		"meow": {
@@ -9834,16 +10719,16 @@
 			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 			"dev": true,
 			"requires": {
-				"camelcase-keys": "2.1.0",
-				"decamelize": "1.2.0",
-				"loud-rejection": "1.6.0",
-				"map-obj": "1.0.1",
-				"minimist": "1.2.0",
-				"normalize-package-data": "2.4.0",
-				"object-assign": "4.1.1",
-				"read-pkg-up": "1.0.1",
-				"redent": "1.0.0",
-				"trim-newlines": "1.0.0"
+				"camelcase-keys": "^2.0.0",
+				"decamelize": "^1.1.2",
+				"loud-rejection": "^1.0.0",
+				"map-obj": "^1.0.1",
+				"minimist": "^1.1.3",
+				"normalize-package-data": "^2.3.4",
+				"object-assign": "^4.0.1",
+				"read-pkg-up": "^1.0.1",
+				"redent": "^1.0.0",
+				"trim-newlines": "^1.0.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -9872,7 +10757,7 @@
 			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "2.3.3"
+				"readable-stream": "^2.0.1"
 			}
 		},
 		"merge2": {
@@ -9893,19 +10778,19 @@
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 			"dev": true,
 			"requires": {
-				"arr-diff": "2.0.0",
-				"array-unique": "0.2.1",
-				"braces": "1.8.5",
-				"expand-brackets": "0.1.5",
-				"extglob": "0.3.2",
-				"filename-regex": "2.0.1",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1",
-				"kind-of": "3.2.2",
-				"normalize-path": "2.1.1",
-				"object.omit": "2.0.1",
-				"parse-glob": "3.0.4",
-				"regex-cache": "0.4.3"
+				"arr-diff": "^2.0.0",
+				"array-unique": "^0.2.1",
+				"braces": "^1.8.2",
+				"expand-brackets": "^0.1.4",
+				"extglob": "^0.3.1",
+				"filename-regex": "^2.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.1",
+				"kind-of": "^3.0.2",
+				"normalize-path": "^2.0.1",
+				"object.omit": "^2.0.0",
+				"parse-glob": "^3.0.4",
+				"regex-cache": "^0.4.2"
 			},
 			"dependencies": {
 				"normalize-path": {
@@ -9914,7 +10799,7 @@
 					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 					"dev": true,
 					"requires": {
-						"remove-trailing-separator": "1.0.2"
+						"remove-trailing-separator": "^1.0.1"
 					}
 				}
 			}
@@ -9925,8 +10810,8 @@
 			"integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.7",
-				"brorand": "1.1.0"
+				"bn.js": "^4.0.0",
+				"brorand": "^1.0.1"
 			}
 		},
 		"mime": {
@@ -9947,7 +10832,7 @@
 			"integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.29.0"
+				"mime-db": "~1.29.0"
 			}
 		},
 		"mimic-fn": {
@@ -9962,7 +10847,7 @@
 			"integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
 			"dev": true,
 			"requires": {
-				"dom-walk": "0.1.1"
+				"dom-walk": "^0.1.0"
 			}
 		},
 		"minimalistic-assert": {
@@ -9983,7 +10868,7 @@
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"dev": true,
 			"requires": {
-				"brace-expansion": "1.1.8"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -9998,8 +10883,8 @@
 			"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
-				"is-plain-obj": "1.1.0"
+				"arrify": "^1.0.1",
+				"is-plain-obj": "^1.1.0"
 			}
 		},
 		"mixin-deep": {
@@ -10008,8 +10893,8 @@
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
 			"dev": true,
 			"requires": {
-				"for-in": "1.0.2",
-				"is-extendable": "1.0.1"
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -10018,7 +10903,7 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
-						"is-plain-object": "2.0.4"
+						"is-plain-object": "^2.0.4"
 					}
 				}
 			}
@@ -10056,8 +10941,8 @@
 			"integrity": "sha1-bn3oalcIcqsXBYrepxYLvsqBTd4=",
 			"dev": true,
 			"requires": {
-				"dns-packet": "1.1.1",
-				"thunky": "0.1.0"
+				"dns-packet": "^1.0.1",
+				"thunky": "^0.1.0"
 			}
 		},
 		"multicast-dns-service-types": {
@@ -10085,18 +10970,18 @@
 			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
 			"dev": true,
 			"requires": {
-				"arr-diff": "4.0.0",
-				"array-unique": "0.3.2",
-				"define-property": "2.0.2",
-				"extend-shallow": "3.0.2",
-				"fragment-cache": "0.2.1",
-				"is-odd": "2.0.0",
-				"is-windows": "1.0.2",
-				"kind-of": "6.0.2",
-				"object.pick": "1.3.0",
-				"regex-not": "1.0.2",
-				"snapdragon": "0.8.2",
-				"to-regex": "3.0.2"
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"fragment-cache": "^0.2.1",
+				"is-odd": "^2.0.0",
+				"is-windows": "^1.0.2",
+				"kind-of": "^6.0.2",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -10137,7 +11022,7 @@
 			"integrity": "sha1-mLL/rvtGEPo5NvHnFDXTBwDeKEA=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3"
+				"inherits": "~2.0.1"
 			}
 		},
 		"node-forge": {
@@ -10158,28 +11043,28 @@
 			"integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
 			"dev": true,
 			"requires": {
-				"assert": "1.4.1",
-				"browserify-zlib": "0.1.4",
-				"buffer": "4.9.1",
-				"console-browserify": "1.1.0",
-				"constants-browserify": "1.0.0",
-				"crypto-browserify": "3.11.1",
-				"domain-browser": "1.1.7",
-				"events": "1.1.1",
+				"assert": "^1.1.1",
+				"browserify-zlib": "^0.1.4",
+				"buffer": "^4.3.0",
+				"console-browserify": "^1.1.0",
+				"constants-browserify": "^1.0.0",
+				"crypto-browserify": "^3.11.0",
+				"domain-browser": "^1.1.1",
+				"events": "^1.0.0",
 				"https-browserify": "0.0.1",
-				"os-browserify": "0.2.1",
+				"os-browserify": "^0.2.0",
 				"path-browserify": "0.0.0",
-				"process": "0.11.10",
-				"punycode": "1.4.1",
-				"querystring-es3": "0.2.1",
-				"readable-stream": "2.3.3",
-				"stream-browserify": "2.0.1",
-				"stream-http": "2.7.2",
-				"string_decoder": "0.10.31",
-				"timers-browserify": "2.0.3",
+				"process": "^0.11.0",
+				"punycode": "^1.2.4",
+				"querystring-es3": "^0.2.0",
+				"readable-stream": "^2.0.5",
+				"stream-browserify": "^2.0.1",
+				"stream-http": "^2.3.1",
+				"string_decoder": "^0.10.25",
+				"timers-browserify": "^2.0.2",
 				"tty-browserify": "0.0.0",
-				"url": "0.11.0",
-				"util": "0.10.3",
+				"url": "^0.11.0",
+				"util": "^0.10.3",
 				"vm-browserify": "0.0.4"
 			},
 			"dependencies": {
@@ -10189,9 +11074,9 @@
 					"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
 					"dev": true,
 					"requires": {
-						"base64-js": "1.2.1",
-						"ieee754": "1.1.8",
-						"isarray": "1.0.0"
+						"base64-js": "^1.0.2",
+						"ieee754": "^1.1.4",
+						"isarray": "^1.0.0"
 					}
 				},
 				"https-browserify": {
@@ -10218,8 +11103,8 @@
 					"integrity": "sha512-+JAqyNgg+M8+gXIrq2EeUr4kZqRz47Ysco7X5QKRGScRE9HIHckyHD1asozSFGeqx2nmPCgA8T5tIGVO0ML7/w==",
 					"dev": true,
 					"requires": {
-						"global": "4.3.2",
-						"setimmediate": "1.0.5"
+						"global": "^4.3.2",
+						"setimmediate": "^1.0.4"
 					}
 				}
 			}
@@ -10230,10 +11115,10 @@
 			"integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
 			"dev": true,
 			"requires": {
-				"growly": "1.3.0",
-				"semver": "5.4.1",
-				"shellwords": "0.1.1",
-				"which": "1.3.0"
+				"growly": "^1.3.0",
+				"semver": "^5.4.1",
+				"shellwords": "^0.1.1",
+				"which": "^1.3.0"
 			}
 		},
 		"normalize-package-data": {
@@ -10242,10 +11127,10 @@
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "2.5.0",
-				"is-builtin-module": "1.0.0",
-				"semver": "5.4.1",
-				"validate-npm-package-license": "3.0.1"
+				"hosted-git-info": "^2.1.4",
+				"is-builtin-module": "^1.0.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
 			}
 		},
 		"normalize-path": {
@@ -10266,7 +11151,7 @@
 			"integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
 			"dev": true,
 			"requires": {
-				"which": "1.3.0"
+				"which": "^1.2.10"
 			}
 		},
 		"npm-run-path": {
@@ -10275,7 +11160,7 @@
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"dev": true,
 			"requires": {
-				"path-key": "2.0.1"
+				"path-key": "^2.0.0"
 			}
 		},
 		"npm-which": {
@@ -10284,9 +11169,9 @@
 			"integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
 			"dev": true,
 			"requires": {
-				"commander": "2.15.1",
-				"npm-path": "2.0.4",
-				"which": "1.3.0"
+				"commander": "^2.9.0",
+				"npm-path": "^2.0.2",
+				"which": "^1.2.10"
 			}
 		},
 		"npmlog": {
@@ -10295,10 +11180,10 @@
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 			"dev": true,
 			"requires": {
-				"are-we-there-yet": "1.1.4",
-				"console-control-strings": "1.1.0",
-				"gauge": "2.7.4",
-				"set-blocking": "2.0.0"
+				"are-we-there-yet": "~1.1.2",
+				"console-control-strings": "~1.1.0",
+				"gauge": "~2.7.3",
+				"set-blocking": "~2.0.0"
 			}
 		},
 		"nth-check": {
@@ -10307,7 +11192,7 @@
 			"integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
 			"dev": true,
 			"requires": {
-				"boolbase": "1.0.0"
+				"boolbase": "~1.0.0"
 			}
 		},
 		"num2fraction": {
@@ -10346,9 +11231,9 @@
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
 			"dev": true,
 			"requires": {
-				"copy-descriptor": "0.1.1",
-				"define-property": "0.2.5",
-				"kind-of": "3.2.2"
+				"copy-descriptor": "^0.1.0",
+				"define-property": "^0.2.5",
+				"kind-of": "^3.0.3"
 			},
 			"dependencies": {
 				"define-property": {
@@ -10357,7 +11242,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -10366,7 +11251,7 @@
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -10375,7 +11260,7 @@
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -10384,9 +11269,9 @@
 					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "0.1.6",
-						"is-data-descriptor": "0.1.4",
-						"kind-of": "5.1.0"
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -10411,7 +11296,7 @@
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 			"dev": true,
 			"requires": {
-				"isobject": "3.0.1"
+				"isobject": "^3.0.0"
 			},
 			"dependencies": {
 				"isobject": {
@@ -10428,8 +11313,8 @@
 			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.2",
-				"es-abstract": "1.11.0"
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.5.1"
 			}
 		},
 		"object.omit": {
@@ -10438,8 +11323,8 @@
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 			"dev": true,
 			"requires": {
-				"for-own": "0.1.5",
-				"is-extendable": "0.1.1"
+				"for-own": "^0.1.4",
+				"is-extendable": "^0.1.1"
 			}
 		},
 		"object.pick": {
@@ -10448,7 +11333,7 @@
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
 			"dev": true,
 			"requires": {
-				"isobject": "3.0.1"
+				"isobject": "^3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -10465,10 +11350,10 @@
 			"integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.2",
-				"es-abstract": "1.11.0",
-				"function-bind": "1.1.1",
-				"has": "1.0.1"
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.6.1",
+				"function-bind": "^1.1.0",
+				"has": "^1.0.1"
 			}
 		},
 		"obuf": {
@@ -10498,7 +11383,7 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"onetime": {
@@ -10507,7 +11392,7 @@
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "1.1.0"
+				"mimic-fn": "^1.0.0"
 			}
 		},
 		"optimist": {
@@ -10516,8 +11401,8 @@
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
 			"dev": true,
 			"requires": {
-				"minimist": "0.0.8",
-				"wordwrap": "0.0.3"
+				"minimist": "~0.0.1",
+				"wordwrap": "~0.0.2"
 			},
 			"dependencies": {
 				"wordwrap": {
@@ -10534,11 +11419,11 @@
 			"integrity": "sha1-QyavhlfEpf8y2vcmYxdU9yq3/bw=",
 			"dev": true,
 			"requires": {
-				"acorn": "3.3.0",
-				"concat-stream": "1.6.2",
-				"estree-walker": "0.3.1",
-				"magic-string": "0.16.0",
-				"yargs": "4.8.1"
+				"acorn": "^3.3.0",
+				"concat-stream": "^1.5.1",
+				"estree-walker": "^0.3.0",
+				"magic-string": "^0.16.0",
+				"yargs": "^4.8.1"
 			},
 			"dependencies": {
 				"acorn": {
@@ -10555,12 +11440,12 @@
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"dev": true,
 			"requires": {
-				"deep-is": "0.1.3",
-				"fast-levenshtein": "2.0.6",
-				"levn": "0.3.0",
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2",
-				"wordwrap": "1.0.0"
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.4",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"wordwrap": "~1.0.0"
 			}
 		},
 		"ora": {
@@ -10569,10 +11454,10 @@
 			"integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
 			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"cli-cursor": "1.0.2",
-				"cli-spinners": "0.1.2",
-				"object-assign": "4.1.1"
+				"chalk": "^1.1.1",
+				"cli-cursor": "^1.0.2",
+				"cli-spinners": "^0.1.2",
+				"object-assign": "^4.0.1"
 			},
 			"dependencies": {
 				"cli-cursor": {
@@ -10581,12 +11466,12 @@
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 					"dev": true,
 					"requires": {
-						"restore-cursor": "1.0.1"
+						"restore-cursor": "^1.0.1"
 					}
 				},
 				"onetime": {
 					"version": "1.1.0",
-					"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
 					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
 					"dev": true
 				},
@@ -10596,8 +11481,8 @@
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 					"dev": true,
 					"requires": {
-						"exit-hook": "1.1.1",
-						"onetime": "1.1.0"
+						"exit-hook": "^1.0.0",
+						"onetime": "^1.0.0"
 					}
 				}
 			}
@@ -10608,7 +11493,7 @@
 			"integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
 			"dev": true,
 			"requires": {
-				"url-parse": "1.0.5"
+				"url-parse": "1.0.x"
 			},
 			"dependencies": {
 				"url-parse": {
@@ -10617,8 +11502,8 @@
 					"integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
 					"dev": true,
 					"requires": {
-						"querystringify": "0.0.4",
-						"requires-port": "1.0.0"
+						"querystringify": "0.0.x",
+						"requires-port": "1.0.x"
 					}
 				}
 			}
@@ -10635,7 +11520,7 @@
 			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 			"dev": true,
 			"requires": {
-				"lcid": "1.0.0"
+				"lcid": "^1.0.0"
 			}
 		},
 		"os-tmpdir": {
@@ -10662,7 +11547,7 @@
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"dev": true,
 			"requires": {
-				"p-limit": "1.1.0"
+				"p-limit": "^1.1.0"
 			}
 		},
 		"p-map": {
@@ -10683,10 +11568,10 @@
 			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
 			"dev": true,
 			"requires": {
-				"got": "6.7.1",
-				"registry-auth-token": "3.3.2",
-				"registry-url": "3.1.0",
-				"semver": "5.4.1"
+				"got": "^6.7.1",
+				"registry-auth-token": "^3.0.1",
+				"registry-url": "^3.0.3",
+				"semver": "^5.1.0"
 			}
 		},
 		"pako": {
@@ -10701,11 +11586,11 @@
 			"integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
 			"dev": true,
 			"requires": {
-				"asn1.js": "4.9.1",
-				"browserify-aes": "1.0.6",
-				"create-hash": "1.1.3",
-				"evp_bytestokey": "1.0.0",
-				"pbkdf2": "3.0.13"
+				"asn1.js": "^4.0.0",
+				"browserify-aes": "^1.0.0",
+				"create-hash": "^1.1.0",
+				"evp_bytestokey": "^1.0.0",
+				"pbkdf2": "^3.0.3"
 			}
 		},
 		"parse-github-repo-url": {
@@ -10720,10 +11605,10 @@
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 			"dev": true,
 			"requires": {
-				"glob-base": "0.3.0",
-				"is-dotfile": "1.0.3",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1"
+				"glob-base": "^0.3.0",
+				"is-dotfile": "^1.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.0"
 			}
 		},
 		"parse-json": {
@@ -10732,7 +11617,7 @@
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 			"dev": true,
 			"requires": {
-				"error-ex": "1.3.1"
+				"error-ex": "^1.2.0"
 			}
 		},
 		"parseurl": {
@@ -10801,9 +11686,9 @@
 			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1"
+				"graceful-fs": "^4.1.2",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -10820,11 +11705,11 @@
 			"integrity": "sha512-+dCHxDH+djNtjgWmvVC/my3SYBAKpKNqKSjLkp+GtWWYe4XPE+e/PSD2aCanlEZZnqPk2uekTKNC/ccbwd2X2Q==",
 			"dev": true,
 			"requires": {
-				"create-hash": "1.1.3",
-				"create-hmac": "1.1.6",
-				"ripemd160": "2.0.1",
-				"safe-buffer": "5.1.1",
-				"sha.js": "2.4.8"
+				"create-hash": "^1.1.2",
+				"create-hmac": "^1.1.4",
+				"ripemd160": "^2.0.1",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
 			}
 		},
 		"performance-now": {
@@ -10851,7 +11736,7 @@
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"dev": true,
 			"requires": {
-				"pinkie": "2.0.4"
+				"pinkie": "^2.0.0"
 			}
 		},
 		"pkg-dir": {
@@ -10860,7 +11745,7 @@
 			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 			"dev": true,
 			"requires": {
-				"find-up": "2.1.0"
+				"find-up": "^2.1.0"
 			}
 		},
 		"please-upgrade-node": {
@@ -10887,9 +11772,9 @@
 			"integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
 			"dev": true,
 			"requires": {
-				"async": "1.5.2",
-				"debug": "2.6.8",
-				"mkdirp": "0.5.1"
+				"async": "^1.5.2",
+				"debug": "^2.2.0",
+				"mkdirp": "0.5.x"
 			},
 			"dependencies": {
 				"async": {
@@ -10912,9 +11797,9 @@
 			"integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.2",
-				"source-map": "0.6.1",
-				"supports-color": "5.3.0"
+				"chalk": "^2.3.2",
+				"source-map": "^0.6.1",
+				"supports-color": "^5.3.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -10923,7 +11808,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.0"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -10932,9 +11817,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -10955,7 +11840,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -10966,7 +11851,7 @@
 			"integrity": "sha1-vlMnhBEOyylQRPtTlaGABushpzc=",
 			"dev": true,
 			"requires": {
-				"postcss": "6.0.21"
+				"postcss": "^6.0.1"
 			}
 		},
 		"postcss-custom-properties": {
@@ -10975,8 +11860,8 @@
 			"integrity": "sha512-dl/CNaM6z2RBa0vZZqsV6Hunj4HD6Spu7FcAkiVp5B2tgm6xReKKYzI7x7QNx3wTMBNj5v+ylfVcQGMW4xdkHw==",
 			"dev": true,
 			"requires": {
-				"balanced-match": "1.0.0",
-				"postcss": "6.0.21"
+				"balanced-match": "^1.0.0",
+				"postcss": "^6.0.18"
 			}
 		},
 		"postcss-reporter": {
@@ -10985,10 +11870,10 @@
 			"integrity": "sha512-rBkDbaHAu5uywbCR2XE8a25tats3xSOsGNx6mppK6Q9kSFGKc/FyAzfci+fWM2l+K402p1D0pNcfDGxeje5IKg==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.2",
-				"lodash": "4.17.5",
-				"log-symbols": "2.2.0",
-				"postcss": "6.0.21"
+				"chalk": "^2.0.1",
+				"lodash": "^4.17.4",
+				"log-symbols": "^2.0.0",
+				"postcss": "^6.0.8"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -10997,7 +11882,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.0"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -11006,9 +11891,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -11023,7 +11908,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -11064,8 +11949,8 @@
 			"integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "3.0.0",
-				"ansi-styles": "3.2.1"
+				"ansi-regex": "^3.0.0",
+				"ansi-styles": "^3.2.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -11080,7 +11965,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.0"
+						"color-convert": "^1.9.0"
 					}
 				}
 			}
@@ -11115,7 +12000,7 @@
 			"integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
 			"dev": true,
 			"requires": {
-				"forwarded": "0.1.0",
+				"forwarded": "~0.1.0",
 				"ipaddr.js": "1.4.0"
 			}
 		},
@@ -11137,11 +12022,11 @@
 			"integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.7",
-				"browserify-rsa": "4.0.1",
-				"create-hash": "1.1.3",
-				"parse-asn1": "5.1.0",
-				"randombytes": "2.0.5"
+				"bn.js": "^4.1.0",
+				"browserify-rsa": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"parse-asn1": "^5.0.0",
+				"randombytes": "^2.0.1"
 			}
 		},
 		"punycode": {
@@ -11192,8 +12077,8 @@
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
 			"dev": true,
 			"requires": {
-				"is-number": "3.0.0",
-				"kind-of": "4.0.0"
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -11202,7 +12087,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -11211,7 +12096,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -11222,7 +12107,7 @@
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.5"
+						"is-buffer": "^1.1.5"
 					}
 				}
 			}
@@ -11233,7 +12118,7 @@
 			"integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "^5.1.0"
 			}
 		},
 		"range-parser": {
@@ -11248,10 +12133,10 @@
 			"integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
 			"dev": true,
 			"requires": {
-				"deep-extend": "0.4.2",
-				"ini": "1.3.5",
-				"minimist": "1.2.0",
-				"strip-json-comments": "2.0.1"
+				"deep-extend": "~0.4.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
 			},
 			"dependencies": {
 				"minimist": {
@@ -11268,7 +12153,7 @@
 			"integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11"
+				"graceful-fs": "^4.1.2"
 			}
 		},
 		"read-pkg": {
@@ -11277,9 +12162,9 @@
 			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "1.1.0",
-				"normalize-package-data": "2.4.0",
-				"path-type": "1.1.0"
+				"load-json-file": "^1.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^1.0.0"
 			}
 		},
 		"read-pkg-up": {
@@ -11288,8 +12173,8 @@
 			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 			"dev": true,
 			"requires": {
-				"find-up": "1.1.2",
-				"read-pkg": "1.1.0"
+				"find-up": "^1.0.0",
+				"read-pkg": "^1.0.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -11298,8 +12183,8 @@
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"dev": true,
 					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-exists": {
@@ -11308,7 +12193,7 @@
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				}
 			}
@@ -11319,13 +12204,13 @@
 			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
 			"dev": true,
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "1.0.7",
-				"safe-buffer": "5.1.1",
-				"string_decoder": "1.0.3",
-				"util-deprecate": "1.0.2"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~1.0.6",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.0.3",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"readdirp": {
@@ -11334,10 +12219,10 @@
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"minimatch": "3.0.4",
-				"readable-stream": "2.3.3",
-				"set-immediate-shim": "1.0.1"
+				"graceful-fs": "^4.1.2",
+				"minimatch": "^3.0.2",
+				"readable-stream": "^2.0.2",
+				"set-immediate-shim": "^1.0.1"
 			}
 		},
 		"realpath-native": {
@@ -11346,7 +12231,7 @@
 			"integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
 			"dev": true,
 			"requires": {
-				"util.promisify": "1.0.0"
+				"util.promisify": "^1.0.0"
 			}
 		},
 		"redent": {
@@ -11355,8 +12240,8 @@
 			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
 			"dev": true,
 			"requires": {
-				"indent-string": "2.1.0",
-				"strip-indent": "1.0.1"
+				"indent-string": "^2.1.0",
+				"strip-indent": "^1.0.1"
 			},
 			"dependencies": {
 				"strip-indent": {
@@ -11365,7 +12250,7 @@
 					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
 					"dev": true,
 					"requires": {
-						"get-stdin": "4.0.1"
+						"get-stdin": "^4.0.1"
 					}
 				}
 			}
@@ -11388,9 +12273,9 @@
 			"integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0",
-				"private": "0.1.7"
+				"babel-runtime": "^6.18.0",
+				"babel-types": "^6.19.0",
+				"private": "^0.1.6"
 			}
 		},
 		"regex-cache": {
@@ -11399,8 +12284,8 @@
 			"integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
 			"dev": true,
 			"requires": {
-				"is-equal-shallow": "0.1.3",
-				"is-primitive": "2.0.0"
+				"is-equal-shallow": "^0.1.3",
+				"is-primitive": "^2.0.0"
 			}
 		},
 		"regex-not": {
@@ -11409,8 +12294,8 @@
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "3.0.2",
-				"safe-regex": "1.1.0"
+				"extend-shallow": "^3.0.2",
+				"safe-regex": "^1.1.0"
 			}
 		},
 		"regexpp": {
@@ -11425,9 +12310,9 @@
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
 			"dev": true,
 			"requires": {
-				"regenerate": "1.3.2",
-				"regjsgen": "0.2.0",
-				"regjsparser": "0.1.5"
+				"regenerate": "^1.2.1",
+				"regjsgen": "^0.2.0",
+				"regjsparser": "^0.1.4"
 			}
 		},
 		"registry-auth-token": {
@@ -11436,8 +12321,8 @@
 			"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
 			"dev": true,
 			"requires": {
-				"rc": "1.2.6",
-				"safe-buffer": "5.1.1"
+				"rc": "^1.1.6",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"registry-url": {
@@ -11446,7 +12331,7 @@
 			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
 			"dev": true,
 			"requires": {
-				"rc": "1.2.6"
+				"rc": "^1.0.1"
 			}
 		},
 		"regjsgen": {
@@ -11461,7 +12346,7 @@
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
 			"dev": true,
 			"requires": {
-				"jsesc": "0.5.0"
+				"jsesc": "~0.5.0"
 			},
 			"dependencies": {
 				"jsesc": {
@@ -11496,7 +12381,7 @@
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"dev": true,
 			"requires": {
-				"is-finite": "1.0.2"
+				"is-finite": "^1.0.0"
 			}
 		},
 		"request": {
@@ -11505,28 +12390,28 @@
 			"integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
 			"dev": true,
 			"requires": {
-				"aws-sign2": "0.7.0",
-				"aws4": "1.6.0",
-				"caseless": "0.12.0",
-				"combined-stream": "1.0.5",
-				"extend": "3.0.1",
-				"forever-agent": "0.6.1",
-				"form-data": "2.3.2",
-				"har-validator": "5.0.3",
-				"hawk": "6.0.2",
-				"http-signature": "1.2.0",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.18",
-				"oauth-sign": "0.8.2",
-				"performance-now": "2.1.0",
-				"qs": "6.5.1",
-				"safe-buffer": "5.1.1",
-				"stringstream": "0.0.5",
-				"tough-cookie": "2.3.4",
-				"tunnel-agent": "0.6.0",
-				"uuid": "3.1.0"
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.6.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.5",
+				"extend": "~3.0.1",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.1",
+				"har-validator": "~5.0.3",
+				"hawk": "~6.0.2",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.17",
+				"oauth-sign": "~0.8.2",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.1",
+				"safe-buffer": "^5.1.1",
+				"stringstream": "~0.0.5",
+				"tough-cookie": "~2.3.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.1.0"
 			},
 			"dependencies": {
 				"mime-db": {
@@ -11541,7 +12426,7 @@
 					"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
 					"dev": true,
 					"requires": {
-						"mime-db": "1.33.0"
+						"mime-db": "~1.33.0"
 					}
 				},
 				"qs": {
@@ -11558,7 +12443,7 @@
 			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
 			"dev": true,
 			"requires": {
-				"lodash": "4.17.5"
+				"lodash": "^4.13.1"
 			}
 		},
 		"request-promise-native": {
@@ -11568,8 +12453,8 @@
 			"dev": true,
 			"requires": {
 				"request-promise-core": "1.1.1",
-				"stealthy-require": "1.1.1",
-				"tough-cookie": "2.3.4"
+				"stealthy-require": "^1.1.0",
+				"tough-cookie": ">=2.3.3"
 			},
 			"dependencies": {
 				"tough-cookie": {
@@ -11578,7 +12463,7 @@
 					"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
 					"dev": true,
 					"requires": {
-						"punycode": "1.4.1"
+						"punycode": "^1.4.1"
 					}
 				}
 			}
@@ -11607,8 +12492,8 @@
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
 			"dev": true,
 			"requires": {
-				"caller-path": "0.1.0",
-				"resolve-from": "1.0.1"
+				"caller-path": "^0.1.0",
+				"resolve-from": "^1.0.0"
 			}
 		},
 		"requires-port": {
@@ -11623,7 +12508,7 @@
 			"integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
 			"dev": true,
 			"requires": {
-				"path-parse": "1.0.5"
+				"path-parse": "^1.0.5"
 			}
 		},
 		"resolve-cwd": {
@@ -11632,7 +12517,7 @@
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
 			"dev": true,
 			"requires": {
-				"resolve-from": "3.0.0"
+				"resolve-from": "^3.0.0"
 			},
 			"dependencies": {
 				"resolve-from": {
@@ -11661,8 +12546,8 @@
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 			"dev": true,
 			"requires": {
-				"onetime": "2.0.1",
-				"signal-exit": "3.0.2"
+				"onetime": "^2.0.0",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"ret": {
@@ -11677,7 +12562,7 @@
 			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
 			"dev": true,
 			"requires": {
-				"align-text": "0.1.4"
+				"align-text": "^0.1.1"
 			}
 		},
 		"rimraf": {
@@ -11686,7 +12571,7 @@
 			"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.2"
+				"glob": "^7.0.5"
 			}
 		},
 		"ripemd160": {
@@ -11695,9 +12580,15 @@
 			"integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
 			"dev": true,
 			"requires": {
-				"hash-base": "2.0.2",
-				"inherits": "2.0.3"
+				"hash-base": "^2.0.0",
+				"inherits": "^2.0.1"
 			}
+		},
+		"rsvp": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+			"integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+			"dev": true
 		},
 		"run-async": {
 			"version": "2.3.0",
@@ -11705,7 +12596,7 @@
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
 			"dev": true,
 			"requires": {
-				"is-promise": "2.1.0"
+				"is-promise": "^2.1.0"
 			}
 		},
 		"rx-lite": {
@@ -11720,7 +12611,7 @@
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
 			"dev": true,
 			"requires": {
-				"rx-lite": "4.0.8"
+				"rx-lite": "*"
 			}
 		},
 		"rxjs": {
@@ -11752,23 +12643,24 @@
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"dev": true,
 			"requires": {
-				"ret": "0.1.15"
+				"ret": "~0.1.10"
 			}
 		},
 		"sane": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/sane/-/sane-2.5.0.tgz",
-			"integrity": "sha512-glfKd7YH4UCrh/7dD+UESsr8ylKWRE7UQPoXuz28FgmcF0ViJQhCTCCZHICRKxf8G8O1KdLEn20dcICK54c7ew==",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
+			"integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
 			"dev": true,
 			"requires": {
-				"anymatch": "2.0.0",
-				"exec-sh": "0.2.1",
-				"fb-watchman": "2.0.0",
-				"fsevents": "1.1.2",
-				"micromatch": "3.1.10",
-				"minimist": "1.2.0",
-				"walker": "1.0.7",
-				"watch": "0.18.0"
+				"anymatch": "^2.0.0",
+				"capture-exit": "^1.2.0",
+				"exec-sh": "^0.2.0",
+				"fb-watchman": "^2.0.0",
+				"fsevents": "^1.2.3",
+				"micromatch": "^3.1.4",
+				"minimist": "^1.1.1",
+				"walker": "~1.0.5",
+				"watch": "~0.18.0"
 			},
 			"dependencies": {
 				"anymatch": {
@@ -11777,8 +12669,8 @@
 					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 					"dev": true,
 					"requires": {
-						"micromatch": "3.1.10",
-						"normalize-path": "2.1.1"
+						"micromatch": "^3.1.4",
+						"normalize-path": "^2.1.1"
 					}
 				},
 				"arr-diff": {
@@ -11794,41 +12686,30 @@
 					"dev": true
 				},
 				"braces": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
-					"integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"kind-of": "6.0.2",
-						"repeat-element": "1.1.2",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "1.0.2"
-							}
-						},
 						"extend-shallow": {
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -11839,13 +12720,13 @@
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"dev": true,
 					"requires": {
-						"debug": "2.6.8",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -11854,7 +12735,7 @@
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
@@ -11863,7 +12744,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-descriptor": {
@@ -11872,9 +12753,9 @@
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							}
 						},
 						"kind-of": {
@@ -11891,14 +12772,14 @@
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"dev": true,
 					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -11907,7 +12788,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
@@ -11916,7 +12797,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -11927,10 +12808,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -11939,8 +12820,537 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
+						}
+					}
+				},
+				"fsevents": {
+					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+					"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"nan": "^2.9.2",
+						"node-pre-gyp": "^0.10.0"
+					},
+					"dependencies": {
+						"abbrev": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"ansi-regex": {
+							"version": "2.1.1",
+							"bundled": true,
+							"dev": true
+						},
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"are-we-there-yet": {
+							"version": "1.1.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"delegates": "^1.0.0",
+								"readable-stream": "^2.0.6"
+							}
+						},
+						"balanced-match": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true
+						},
+						"brace-expansion": {
+							"version": "1.1.11",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"balanced-match": "^1.0.0",
+								"concat-map": "0.0.1"
+							}
+						},
+						"chownr": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"code-point-at": {
+							"version": "1.1.0",
+							"bundled": true,
+							"dev": true
+						},
+						"concat-map": {
+							"version": "0.0.1",
+							"bundled": true,
+							"dev": true
+						},
+						"console-control-strings": {
+							"version": "1.1.0",
+							"bundled": true,
+							"dev": true
+						},
+						"core-util-is": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"debug": {
+							"version": "2.6.9",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						},
+						"deep-extend": {
+							"version": "0.5.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"delegates": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"detect-libc": {
+							"version": "1.0.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"fs-minipass": {
+							"version": "1.2.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.2.1"
+							}
+						},
+						"fs.realpath": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"gauge": {
+							"version": "2.7.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"aproba": "^1.0.3",
+								"console-control-strings": "^1.0.0",
+								"has-unicode": "^2.0.0",
+								"object-assign": "^4.1.0",
+								"signal-exit": "^3.0.0",
+								"string-width": "^1.0.1",
+								"strip-ansi": "^3.0.1",
+								"wide-align": "^1.1.0"
+							}
+						},
+						"glob": {
+							"version": "7.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						},
+						"has-unicode": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"iconv-lite": {
+							"version": "0.4.21",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"safer-buffer": "^2.1.0"
+							}
+						},
+						"ignore-walk": {
+							"version": "3.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minimatch": "^3.0.4"
+							}
+						},
+						"inflight": {
+							"version": "1.0.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"once": "^1.3.0",
+								"wrappy": "1"
+							}
+						},
+						"inherits": {
+							"version": "2.0.3",
+							"bundled": true,
+							"dev": true
+						},
+						"ini": {
+							"version": "1.3.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"number-is-nan": "^1.0.0"
+							}
+						},
+						"isarray": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						},
+						"minimist": {
+							"version": "0.0.8",
+							"bundled": true,
+							"dev": true
+						},
+						"minipass": {
+							"version": "2.2.4",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "^5.1.1",
+								"yallist": "^3.0.0"
+							}
+						},
+						"minizlib": {
+							"version": "1.1.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.2.1"
+							}
+						},
+						"mkdirp": {
+							"version": "0.5.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"minimist": "0.0.8"
+							}
+						},
+						"ms": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"needle": {
+							"version": "2.2.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"debug": "^2.1.2",
+								"iconv-lite": "^0.4.4",
+								"sax": "^1.2.4"
+							}
+						},
+						"node-pre-gyp": {
+							"version": "0.10.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"detect-libc": "^1.0.2",
+								"mkdirp": "^0.5.1",
+								"needle": "^2.2.0",
+								"nopt": "^4.0.1",
+								"npm-packlist": "^1.1.6",
+								"npmlog": "^4.0.2",
+								"rc": "^1.1.7",
+								"rimraf": "^2.6.1",
+								"semver": "^5.3.0",
+								"tar": "^4"
+							}
+						},
+						"nopt": {
+							"version": "4.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"abbrev": "1",
+								"osenv": "^0.1.4"
+							}
+						},
+						"npm-bundled": {
+							"version": "1.0.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"npm-packlist": {
+							"version": "1.1.10",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"ignore-walk": "^3.0.1",
+								"npm-bundled": "^1.0.1"
+							}
+						},
+						"npmlog": {
+							"version": "4.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"are-we-there-yet": "~1.1.2",
+								"console-control-strings": "~1.1.0",
+								"gauge": "~2.7.3",
+								"set-blocking": "~2.0.0"
+							}
+						},
+						"number-is-nan": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true
+						},
+						"object-assign": {
+							"version": "4.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"once": {
+							"version": "1.4.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"wrappy": "1"
+							}
+						},
+						"os-homedir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"os-tmpdir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"osenv": {
+							"version": "0.1.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"os-homedir": "^1.0.0",
+								"os-tmpdir": "^1.0.0"
+							}
+						},
+						"path-is-absolute": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"process-nextick-args": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"rc": {
+							"version": "1.2.7",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"deep-extend": "^0.5.1",
+								"ini": "~1.3.0",
+								"minimist": "^1.2.0",
+								"strip-json-comments": "~2.0.1"
+							},
+							"dependencies": {
+								"minimist": {
+									"version": "1.2.0",
+									"bundled": true,
+									"dev": true,
+									"optional": true
+								}
+							}
+						},
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"rimraf": {
+							"version": "2.6.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"glob": "^7.0.5"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.1",
+							"bundled": true,
+							"dev": true
+						},
+						"safer-buffer": {
+							"version": "2.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"sax": {
+							"version": "1.2.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"semver": {
+							"version": "5.5.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"set-blocking": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"signal-exit": {
+							"version": "3.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "3.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^2.0.0"
+							}
+						},
+						"strip-json-comments": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"tar": {
+							"version": "4.4.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"chownr": "^1.0.1",
+								"fs-minipass": "^1.2.5",
+								"minipass": "^2.2.4",
+								"minizlib": "^1.1.0",
+								"mkdirp": "^0.5.0",
+								"safe-buffer": "^5.1.1",
+								"yallist": "^3.0.2"
+							}
+						},
+						"util-deprecate": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"wide-align": {
+							"version": "1.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"string-width": "^1.0.2"
+							}
+						},
+						"wrappy": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true
+						},
+						"yallist": {
+							"version": "3.0.2",
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
@@ -11950,7 +13360,7 @@
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -11959,7 +13369,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -11970,7 +13380,7 @@
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -11979,7 +13389,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -11990,7 +13400,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -11999,7 +13409,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -12022,19 +13432,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.1",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.9",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					}
 				},
 				"minimist": {
@@ -12043,13 +13453,20 @@
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				},
+				"nan": {
+					"version": "2.10.0",
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+					"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+					"dev": true,
+					"optional": true
+				},
 				"normalize-path": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 					"dev": true,
 					"requires": {
-						"remove-trailing-separator": "1.0.2"
+						"remove-trailing-separator": "^1.0.1"
 					}
 				}
 			}
@@ -12088,18 +13505,18 @@
 			"dev": true,
 			"requires": {
 				"debug": "2.6.7",
-				"depd": "1.1.1",
-				"destroy": "1.0.4",
-				"encodeurl": "1.0.1",
-				"escape-html": "1.0.3",
-				"etag": "1.8.0",
+				"depd": "~1.1.0",
+				"destroy": "~1.0.4",
+				"encodeurl": "~1.0.1",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.0",
 				"fresh": "0.5.0",
-				"http-errors": "1.6.2",
+				"http-errors": "~1.6.1",
 				"mime": "1.3.4",
 				"ms": "2.0.0",
-				"on-finished": "2.3.0",
-				"range-parser": "1.2.0",
-				"statuses": "1.3.1"
+				"on-finished": "~2.3.0",
+				"range-parser": "~1.2.0",
+				"statuses": "~1.3.1"
 			},
 			"dependencies": {
 				"debug": {
@@ -12119,13 +13536,13 @@
 			"integrity": "sha1-0rKA/FYNYW7oG0i/D6gqvtJIXOc=",
 			"dev": true,
 			"requires": {
-				"accepts": "1.3.3",
+				"accepts": "~1.3.3",
 				"batch": "0.6.1",
 				"debug": "2.6.8",
-				"escape-html": "1.0.3",
-				"http-errors": "1.6.2",
-				"mime-types": "2.1.16",
-				"parseurl": "1.3.1"
+				"escape-html": "~1.0.3",
+				"http-errors": "~1.6.1",
+				"mime-types": "~2.1.15",
+				"parseurl": "~1.3.1"
 			}
 		},
 		"serve-static": {
@@ -12134,9 +13551,9 @@
 			"integrity": "sha1-n0uhni8wMMVH+K+ZEHg47DjVseI=",
 			"dev": true,
 			"requires": {
-				"encodeurl": "1.0.1",
-				"escape-html": "1.0.3",
-				"parseurl": "1.3.1",
+				"encodeurl": "~1.0.1",
+				"escape-html": "~1.0.3",
+				"parseurl": "~1.3.1",
 				"send": "0.15.3"
 			}
 		},
@@ -12158,10 +13575,10 @@
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "2.0.1",
-				"is-extendable": "0.1.1",
-				"is-plain-object": "2.0.4",
-				"split-string": "3.1.0"
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -12170,7 +13587,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				}
 			}
@@ -12193,7 +13610,7 @@
 			"integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3"
+				"inherits": "^2.0.1"
 			}
 		},
 		"shebang-command": {
@@ -12202,7 +13619,7 @@
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"dev": true,
 			"requires": {
-				"shebang-regex": "1.0.0"
+				"shebang-regex": "^1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -12235,7 +13652,7 @@
 			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
 			"dev": true,
 			"requires": {
-				"is-fullwidth-code-point": "2.0.0"
+				"is-fullwidth-code-point": "^2.0.0"
 			}
 		},
 		"snapdragon": {
@@ -12244,14 +13661,14 @@
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 			"dev": true,
 			"requires": {
-				"base": "0.11.2",
-				"debug": "2.6.8",
-				"define-property": "0.2.5",
-				"extend-shallow": "2.0.1",
-				"map-cache": "0.2.2",
-				"source-map": "0.5.6",
-				"source-map-resolve": "0.5.1",
-				"use": "3.1.0"
+				"base": "^0.11.1",
+				"debug": "^2.2.0",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"map-cache": "^0.2.2",
+				"source-map": "^0.5.6",
+				"source-map-resolve": "^0.5.0",
+				"use": "^3.1.0"
 			},
 			"dependencies": {
 				"define-property": {
@@ -12260,7 +13677,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				},
 				"extend-shallow": {
@@ -12269,7 +13686,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -12278,7 +13695,7 @@
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -12287,7 +13704,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -12298,7 +13715,7 @@
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -12307,7 +13724,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -12318,9 +13735,9 @@
 					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "0.1.6",
-						"is-data-descriptor": "0.1.4",
-						"kind-of": "5.1.0"
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
 					}
 				},
 				"kind-of": {
@@ -12337,9 +13754,9 @@
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
 			"dev": true,
 			"requires": {
-				"define-property": "1.0.0",
-				"isobject": "3.0.1",
-				"snapdragon-util": "3.0.1"
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.0",
+				"snapdragon-util": "^3.0.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -12348,7 +13765,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "1.0.2"
+						"is-descriptor": "^1.0.0"
 					}
 				},
 				"isobject": {
@@ -12365,7 +13782,7 @@
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.2.0"
 			}
 		},
 		"sntp": {
@@ -12374,7 +13791,7 @@
 			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
 			"dev": true,
 			"requires": {
-				"hoek": "4.2.1"
+				"hoek": "4.x.x"
 			}
 		},
 		"sockjs": {
@@ -12383,8 +13800,8 @@
 			"integrity": "sha1-2bKJMWyn33dZXvKZ4HXw+TfrQgc=",
 			"dev": true,
 			"requires": {
-				"faye-websocket": "0.10.0",
-				"uuid": "2.0.3"
+				"faye-websocket": "^0.10.0",
+				"uuid": "^2.0.2"
 			},
 			"dependencies": {
 				"uuid": {
@@ -12401,12 +13818,12 @@
 			"integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
 			"dev": true,
 			"requires": {
-				"debug": "2.6.8",
+				"debug": "^2.6.6",
 				"eventsource": "0.1.6",
-				"faye-websocket": "0.11.1",
-				"inherits": "2.0.3",
-				"json3": "3.3.2",
-				"url-parse": "1.1.9"
+				"faye-websocket": "~0.11.0",
+				"inherits": "^2.0.1",
+				"json3": "^3.3.2",
+				"url-parse": "^1.1.8"
 			},
 			"dependencies": {
 				"faye-websocket": {
@@ -12415,7 +13832,7 @@
 					"integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
 					"dev": true,
 					"requires": {
-						"websocket-driver": "0.6.5"
+						"websocket-driver": ">=0.5.1"
 					}
 				}
 			}
@@ -12426,7 +13843,7 @@
 			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
 			"dev": true,
 			"requires": {
-				"is-plain-obj": "1.1.0"
+				"is-plain-obj": "^1.0.0"
 			}
 		},
 		"source-list-map": {
@@ -12447,20 +13864,20 @@
 			"integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
 			"dev": true,
 			"requires": {
-				"atob": "2.0.3",
-				"decode-uri-component": "0.2.0",
-				"resolve-url": "0.2.1",
-				"source-map-url": "0.4.0",
-				"urix": "0.1.0"
+				"atob": "^2.0.0",
+				"decode-uri-component": "^0.2.0",
+				"resolve-url": "^0.2.1",
+				"source-map-url": "^0.4.0",
+				"urix": "^0.1.0"
 			}
 		},
 		"source-map-support": {
-			"version": "0.4.15",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
-			"integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
+			"version": "0.4.18",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
 			"dev": true,
 			"requires": {
-				"source-map": "0.5.6"
+				"source-map": "^0.5.6"
 			}
 		},
 		"source-map-url": {
@@ -12475,7 +13892,7 @@
 			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
 			"dev": true,
 			"requires": {
-				"spdx-license-ids": "1.2.2"
+				"spdx-license-ids": "^1.0.2"
 			}
 		},
 		"spdx-expression-parse": {
@@ -12496,12 +13913,12 @@
 			"integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
 			"dev": true,
 			"requires": {
-				"debug": "2.6.8",
-				"handle-thing": "1.2.5",
-				"http-deceiver": "1.2.7",
-				"safe-buffer": "5.1.1",
-				"select-hose": "2.0.0",
-				"spdy-transport": "2.0.20"
+				"debug": "^2.6.8",
+				"handle-thing": "^1.2.5",
+				"http-deceiver": "^1.2.7",
+				"safe-buffer": "^5.0.1",
+				"select-hose": "^2.0.0",
+				"spdy-transport": "^2.0.18"
 			}
 		},
 		"spdy-transport": {
@@ -12510,13 +13927,13 @@
 			"integrity": "sha1-c15yBUxIayNU/onnAiVgBKOazk0=",
 			"dev": true,
 			"requires": {
-				"debug": "2.6.8",
-				"detect-node": "2.0.3",
-				"hpack.js": "2.1.6",
-				"obuf": "1.1.1",
-				"readable-stream": "2.3.3",
-				"safe-buffer": "5.1.1",
-				"wbuf": "1.7.2"
+				"debug": "^2.6.8",
+				"detect-node": "^2.0.3",
+				"hpack.js": "^2.1.6",
+				"obuf": "^1.1.1",
+				"readable-stream": "^2.2.9",
+				"safe-buffer": "^5.0.1",
+				"wbuf": "^1.7.2"
 			}
 		},
 		"split": {
@@ -12525,7 +13942,7 @@
 			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
 			"dev": true,
 			"requires": {
-				"through": "2.3.8"
+				"through": "2"
 			}
 		},
 		"split-string": {
@@ -12534,7 +13951,7 @@
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "3.0.2"
+				"extend-shallow": "^3.0.0"
 			}
 		},
 		"split2": {
@@ -12543,7 +13960,7 @@
 			"integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
 			"dev": true,
 			"requires": {
-				"through2": "2.0.3"
+				"through2": "^2.0.2"
 			}
 		},
 		"sprintf-js": {
@@ -12558,14 +13975,14 @@
 			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
 			"dev": true,
 			"requires": {
-				"asn1": "0.2.3",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.1",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.1",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"tweetnacl": "0.14.5"
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"tweetnacl": "~0.14.0"
 			},
 			"dependencies": {
 				"assert-plus": {
@@ -12600,8 +14017,8 @@
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
 			"dev": true,
 			"requires": {
-				"define-property": "0.2.5",
-				"object-copy": "0.1.0"
+				"define-property": "^0.2.5",
+				"object-copy": "^0.1.0"
 			},
 			"dependencies": {
 				"define-property": {
@@ -12610,7 +14027,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -12619,7 +14036,7 @@
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -12628,7 +14045,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -12639,7 +14056,7 @@
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -12648,7 +14065,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -12659,9 +14076,9 @@
 					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "0.1.6",
-						"is-data-descriptor": "0.1.4",
-						"kind-of": "5.1.0"
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
 					}
 				},
 				"kind-of": {
@@ -12690,8 +14107,8 @@
 			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
+				"inherits": "~2.0.1",
+				"readable-stream": "^2.0.2"
 			}
 		},
 		"stream-http": {
@@ -12700,11 +14117,11 @@
 			"integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
 			"dev": true,
 			"requires": {
-				"builtin-status-codes": "3.0.0",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3",
-				"to-arraybuffer": "1.0.1",
-				"xtend": "4.0.1"
+				"builtin-status-codes": "^3.0.0",
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.2.6",
+				"to-arraybuffer": "^1.0.0",
+				"xtend": "^4.0.0"
 			}
 		},
 		"stream-to-observable": {
@@ -12713,7 +14130,7 @@
 			"integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
 			"dev": true,
 			"requires": {
-				"any-observable": "0.2.0"
+				"any-observable": "^0.2.0"
 			}
 		},
 		"string-argv": {
@@ -12728,8 +14145,8 @@
 			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
 			"dev": true,
 			"requires": {
-				"astral-regex": "1.0.0",
-				"strip-ansi": "4.0.0"
+				"astral-regex": "^1.0.0",
+				"strip-ansi": "^4.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -12744,7 +14161,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -12755,8 +14172,8 @@
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"dev": true,
 			"requires": {
-				"is-fullwidth-code-point": "2.0.0",
-				"strip-ansi": "4.0.0"
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -12771,7 +14188,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -12782,7 +14199,7 @@
 			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"stringify-object": {
@@ -12791,9 +14208,9 @@
 			"integrity": "sha512-O696NF21oLiDy8PhpWu8AEqoZHw++QW6mUv0UvKZe8gWSdSvMXkiLufK7OmnP27Dro4GU5kb9U7JIO0mBuCRQg==",
 			"dev": true,
 			"requires": {
-				"get-own-enumerable-property-symbols": "2.0.1",
-				"is-obj": "1.0.1",
-				"is-regexp": "1.0.0"
+				"get-own-enumerable-property-symbols": "^2.0.1",
+				"is-obj": "^1.0.1",
+				"is-regexp": "^1.0.0"
 			}
 		},
 		"stringstream": {
@@ -12808,7 +14225,7 @@
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"strip-bom": {
@@ -12817,7 +14234,7 @@
 			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 			"dev": true,
 			"requires": {
-				"is-utf8": "0.2.1"
+				"is-utf8": "^0.2.0"
 			}
 		},
 		"strip-eof": {
@@ -12844,11 +14261,11 @@
 			"integrity": "sha1-9/uTdYpppXEUAYEnfuoMLrEwH6M=",
 			"dev": true,
 			"requires": {
-				"byline": "5.0.0",
-				"duplexer": "0.1.1",
-				"minimist": "0.1.0",
-				"moment": "2.21.0",
-				"through": "2.3.8"
+				"byline": "^5.0.0",
+				"duplexer": "^0.1.1",
+				"minimist": "^0.1.0",
+				"moment": "^2.6.0",
+				"through": "^2.3.4"
 			},
 			"dependencies": {
 				"minimist": {
@@ -12871,20 +14288,20 @@
 			"integrity": "sha512-nYrifviB77aNKDNKKyuay3M9aYiK6Hv5gJVDdjj2ZXTQmI8WZc8+UPLR5IpVlktJfSu3co/4XcWgrgI6seGBPg==",
 			"dev": true,
 			"requires": {
-				"coa": "2.0.1",
-				"colors": "1.1.2",
-				"css-select": "1.3.0-rc0",
-				"css-select-base-adapter": "0.1.0",
+				"coa": "~2.0.1",
+				"colors": "~1.1.2",
+				"css-select": "~1.3.0-rc0",
+				"css-select-base-adapter": "~0.1.0",
 				"css-tree": "1.0.0-alpha25",
-				"css-url-regex": "1.1.0",
-				"csso": "3.5.0",
-				"js-yaml": "3.10.0",
-				"mkdirp": "0.5.1",
-				"object.values": "1.0.4",
-				"sax": "1.2.4",
-				"stable": "0.1.6",
-				"unquote": "1.1.1",
-				"util.promisify": "1.0.0"
+				"css-url-regex": "^1.1.0",
+				"csso": "^3.5.0",
+				"js-yaml": "~3.10.0",
+				"mkdirp": "~0.5.1",
+				"object.values": "^1.0.4",
+				"sax": "~1.2.4",
+				"stable": "~0.1.6",
+				"unquote": "~1.1.1",
+				"util.promisify": "~1.0.0"
 			},
 			"dependencies": {
 				"css-tree": {
@@ -12893,8 +14310,8 @@
 					"integrity": "sha512-XC6xLW/JqIGirnZuUWHXCHRaAjje2b3OIB0Vj5RIJo6mIi/AdJo30quQl5LxUl0gkXDIrTrFGbMlcZjyFplz1A==",
 					"dev": true,
 					"requires": {
-						"mdn-data": "1.1.1",
-						"source-map": "0.5.6"
+						"mdn-data": "^1.0.0",
+						"source-map": "^0.5.3"
 					}
 				},
 				"js-yaml": {
@@ -12903,8 +14320,8 @@
 					"integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
 					"dev": true,
 					"requires": {
-						"argparse": "1.0.9",
-						"esprima": "4.0.0"
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
 					}
 				}
 			}
@@ -12915,8 +14332,8 @@
 			"integrity": "sha512-K5GcfdH/lZbLyQv2Vi9pDAKUXBLZAn7eRoPGCzV+7gk7Fv/LOB1gLsNfevNSrcapX/q45M8x0XMct9ZjWRFImQ==",
 			"dev": true,
 			"requires": {
-				"cheerio": "0.22.0",
-				"object-assign": "4.1.1"
+				"cheerio": "^0.22.0",
+				"object-assign": "^4.1.0"
 			}
 		},
 		"symbol-observable": {
@@ -12937,12 +14354,12 @@
 			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
 			"dev": true,
 			"requires": {
-				"ajv": "5.5.2",
-				"ajv-keywords": "2.1.1",
-				"chalk": "2.3.2",
-				"lodash": "4.17.5",
+				"ajv": "^5.2.3",
+				"ajv-keywords": "^2.1.0",
+				"chalk": "^2.1.0",
+				"lodash": "^4.17.4",
 				"slice-ansi": "1.0.0",
-				"string-width": "2.1.1"
+				"string-width": "^2.1.1"
 			},
 			"dependencies": {
 				"ajv": {
@@ -12951,10 +14368,10 @@
 					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 					"dev": true,
 					"requires": {
-						"co": "4.6.0",
-						"fast-deep-equal": "1.0.0",
-						"fast-json-stable-stringify": "2.0.0",
-						"json-schema-traverse": "0.3.1"
+						"co": "^4.6.0",
+						"fast-deep-equal": "^1.0.0",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.3.0"
 					}
 				},
 				"ansi-styles": {
@@ -12963,7 +14380,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.0"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -12972,9 +14389,9 @@
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.3.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -12989,7 +14406,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -13012,12 +14429,12 @@
 			"integrity": "sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"is-stream": "1.1.0",
-				"make-dir": "1.2.0",
-				"pify": "3.0.0",
-				"temp-dir": "1.0.0",
-				"uuid": "3.1.0"
+				"graceful-fs": "^4.1.2",
+				"is-stream": "^1.1.0",
+				"make-dir": "^1.0.0",
+				"pify": "^3.0.0",
+				"temp-dir": "^1.0.0",
+				"uuid": "^3.0.1"
 			}
 		},
 		"tempfile": {
@@ -13026,8 +14443,8 @@
 			"integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
 			"dev": true,
 			"requires": {
-				"os-tmpdir": "1.0.2",
-				"uuid": "2.0.3"
+				"os-tmpdir": "^1.0.0",
+				"uuid": "^2.0.1"
 			},
 			"dependencies": {
 				"uuid": {
@@ -13044,11 +14461,11 @@
 			"integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
-				"micromatch": "3.1.10",
-				"object-assign": "4.1.1",
-				"read-pkg-up": "1.0.1",
-				"require-main-filename": "1.0.1"
+				"arrify": "^1.0.1",
+				"micromatch": "^3.1.8",
+				"object-assign": "^4.1.0",
+				"read-pkg-up": "^1.0.1",
+				"require-main-filename": "^1.0.1"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -13064,41 +14481,30 @@
 					"dev": true
 				},
 				"braces": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
-					"integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"kind-of": "6.0.2",
-						"repeat-element": "1.1.2",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "1.0.2"
-							}
-						},
 						"extend-shallow": {
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -13109,13 +14515,13 @@
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"dev": true,
 					"requires": {
-						"debug": "2.6.8",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -13124,7 +14530,7 @@
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "0.1.6"
+								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
@@ -13133,7 +14539,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-descriptor": {
@@ -13142,9 +14548,9 @@
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
 							}
 						},
 						"kind-of": {
@@ -13161,14 +14567,14 @@
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"dev": true,
 					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
 					},
 					"dependencies": {
 						"define-property": {
@@ -13177,7 +14583,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "1.0.2"
+								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
@@ -13186,7 +14592,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -13197,10 +14603,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -13209,7 +14615,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "0.1.1"
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -13220,7 +14626,7 @@
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -13229,7 +14635,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -13240,7 +14646,7 @@
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -13249,7 +14655,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -13260,7 +14666,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -13269,7 +14675,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.5"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -13292,19 +14698,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.1",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.9",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					}
 				}
 			}
@@ -13339,8 +14745,8 @@
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "2.3.3",
-				"xtend": "4.0.1"
+				"readable-stream": "^2.1.5",
+				"xtend": "~4.0.1"
 			}
 		},
 		"thunky": {
@@ -13367,7 +14773,7 @@
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 			"dev": true,
 			"requires": {
-				"os-tmpdir": "1.0.2"
+				"os-tmpdir": "~1.0.2"
 			}
 		},
 		"tmpl": {
@@ -13394,7 +14800,7 @@
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			}
 		},
 		"to-regex": {
@@ -13403,10 +14809,10 @@
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
 			"dev": true,
 			"requires": {
-				"define-property": "2.0.2",
-				"extend-shallow": "3.0.2",
-				"regex-not": "1.0.2",
-				"safe-regex": "1.1.0"
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"regex-not": "^1.0.2",
+				"safe-regex": "^1.1.0"
 			}
 		},
 		"to-regex-range": {
@@ -13415,8 +14821,8 @@
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 			"dev": true,
 			"requires": {
-				"is-number": "3.0.0",
-				"repeat-string": "1.6.1"
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1"
 			},
 			"dependencies": {
 				"is-number": {
@@ -13425,7 +14831,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				}
 			}
@@ -13436,7 +14842,7 @@
 			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
 			"dev": true,
 			"requires": {
-				"punycode": "1.4.1"
+				"punycode": "^1.4.1"
 			}
 		},
 		"tr46": {
@@ -13445,7 +14851,7 @@
 			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
 			"dev": true,
 			"requires": {
-				"punycode": "2.1.0"
+				"punycode": "^2.1.0"
 			},
 			"dependencies": {
 				"punycode": {
@@ -13486,7 +14892,7 @@
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"tweetnacl": {
@@ -13502,7 +14908,7 @@
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "1.1.2"
+				"prelude-ls": "~1.1.2"
 			}
 		},
 		"type-is": {
@@ -13512,7 +14918,7 @@
 			"dev": true,
 			"requires": {
 				"media-typer": "0.3.0",
-				"mime-types": "2.1.16"
+				"mime-types": "~2.1.15"
 			}
 		},
 		"typedarray": {
@@ -13527,9 +14933,9 @@
 			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
 			"dev": true,
 			"requires": {
-				"source-map": "0.5.6",
-				"uglify-to-browserify": "1.0.2",
-				"yargs": "3.10.0"
+				"source-map": "~0.5.1",
+				"uglify-to-browserify": "~1.0.0",
+				"yargs": "~3.10.0"
 			},
 			"dependencies": {
 				"yargs": {
@@ -13538,9 +14944,9 @@
 					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
 					"dev": true,
 					"requires": {
-						"camelcase": "1.2.1",
-						"cliui": "2.1.0",
-						"decamelize": "1.2.0",
+						"camelcase": "^1.0.2",
+						"cliui": "^2.1.0",
+						"decamelize": "^1.0.0",
 						"window-size": "0.1.0"
 					}
 				}
@@ -13559,9 +14965,9 @@
 			"integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
 			"dev": true,
 			"requires": {
-				"source-map": "0.5.6",
-				"uglify-js": "2.8.29",
-				"webpack-sources": "1.0.1"
+				"source-map": "^0.5.6",
+				"uglify-js": "^2.8.29",
+				"webpack-sources": "^1.0.1"
 			}
 		},
 		"union-value": {
@@ -13570,10 +14976,10 @@
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
 			"dev": true,
 			"requires": {
-				"arr-union": "3.1.0",
-				"get-value": "2.0.6",
-				"is-extendable": "0.1.1",
-				"set-value": "0.4.3"
+				"arr-union": "^3.1.0",
+				"get-value": "^2.0.6",
+				"is-extendable": "^0.1.1",
+				"set-value": "^0.4.3"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -13582,7 +14988,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				},
 				"set-value": {
@@ -13591,10 +14997,10 @@
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-extendable": "0.1.1",
-						"is-plain-object": "2.0.4",
-						"to-object-path": "0.3.0"
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.1",
+						"to-object-path": "^0.3.0"
 					}
 				}
 			}
@@ -13623,8 +15029,8 @@
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
 			"dev": true,
 			"requires": {
-				"has-value": "0.3.1",
-				"isobject": "3.0.1"
+				"has-value": "^0.3.1",
+				"isobject": "^3.0.0"
 			},
 			"dependencies": {
 				"has-value": {
@@ -13633,9 +15039,9 @@
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
 					"dev": true,
 					"requires": {
-						"get-value": "2.0.6",
-						"has-values": "0.1.4",
-						"isobject": "2.1.0"
+						"get-value": "^2.0.3",
+						"has-values": "^0.1.4",
+						"isobject": "^2.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -13699,8 +15105,8 @@
 			"integrity": "sha1-xn8dd11R8KGJEd17P/rSe7nlvRk=",
 			"dev": true,
 			"requires": {
-				"querystringify": "1.0.0",
-				"requires-port": "1.0.0"
+				"querystringify": "~1.0.0",
+				"requires-port": "1.0.x"
 			},
 			"dependencies": {
 				"querystringify": {
@@ -13717,7 +15123,7 @@
 			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
 			"dev": true,
 			"requires": {
-				"prepend-http": "1.0.4"
+				"prepend-http": "^1.0.1"
 			}
 		},
 		"use": {
@@ -13726,7 +15132,7 @@
 			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
 			"dev": true,
 			"requires": {
-				"kind-of": "6.0.2"
+				"kind-of": "^6.0.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -13766,8 +15172,8 @@
 			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.2",
-				"object.getownpropertydescriptors": "2.0.3"
+				"define-properties": "^1.1.2",
+				"object.getownpropertydescriptors": "^2.0.3"
 			}
 		},
 		"utils-merge": {
@@ -13788,8 +15194,8 @@
 			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
 			"dev": true,
 			"requires": {
-				"spdx-correct": "1.0.2",
-				"spdx-expression-parse": "1.0.4"
+				"spdx-correct": "~1.0.0",
+				"spdx-expression-parse": "~1.0.0"
 			}
 		},
 		"vary": {
@@ -13804,9 +15210,9 @@
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0",
+				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
+				"extsprintf": "^1.2.0"
 			},
 			"dependencies": {
 				"assert-plus": {
@@ -13838,7 +15244,7 @@
 			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
 			"dev": true,
 			"requires": {
-				"browser-process-hrtime": "0.1.2"
+				"browser-process-hrtime": "^0.1.2"
 			}
 		},
 		"walker": {
@@ -13847,7 +15253,7 @@
 			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
 			"dev": true,
 			"requires": {
-				"makeerror": "1.0.11"
+				"makeerror": "1.0.x"
 			}
 		},
 		"watch": {
@@ -13856,8 +15262,8 @@
 			"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
 			"dev": true,
 			"requires": {
-				"exec-sh": "0.2.1",
-				"minimist": "1.2.0"
+				"exec-sh": "^0.2.0",
+				"minimist": "^1.2.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -13874,9 +15280,9 @@
 			"integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
 			"dev": true,
 			"requires": {
-				"async": "2.5.0",
-				"chokidar": "1.7.0",
-				"graceful-fs": "4.1.11"
+				"async": "^2.1.2",
+				"chokidar": "^1.7.0",
+				"graceful-fs": "^4.1.2"
 			}
 		},
 		"wbuf": {
@@ -13885,7 +15291,7 @@
 			"integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
 			"dev": true,
 			"requires": {
-				"minimalistic-assert": "1.0.0"
+				"minimalistic-assert": "^1.0.0"
 			}
 		},
 		"wcwidth": {
@@ -13894,7 +15300,7 @@
 			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
 			"dev": true,
 			"requires": {
-				"defaults": "1.0.3"
+				"defaults": "^1.0.3"
 			}
 		},
 		"webidl-conversions": {
@@ -13909,28 +15315,28 @@
 			"integrity": "sha1-TD9PP7MYFVpNsMtqNv8FxWl0GPQ=",
 			"dev": true,
 			"requires": {
-				"acorn": "5.1.1",
-				"acorn-dynamic-import": "2.0.2",
-				"ajv": "5.2.2",
-				"ajv-keywords": "2.1.0",
-				"async": "2.5.0",
-				"enhanced-resolve": "3.4.1",
-				"escope": "3.6.0",
-				"interpret": "1.0.3",
-				"json-loader": "0.5.7",
-				"json5": "0.5.1",
-				"loader-runner": "2.3.0",
-				"loader-utils": "1.1.0",
-				"memory-fs": "0.4.1",
-				"mkdirp": "0.5.1",
-				"node-libs-browser": "2.0.0",
-				"source-map": "0.5.6",
-				"supports-color": "4.2.1",
-				"tapable": "0.2.8",
-				"uglifyjs-webpack-plugin": "0.4.6",
-				"watchpack": "1.4.0",
-				"webpack-sources": "1.0.1",
-				"yargs": "8.0.2"
+				"acorn": "^5.0.0",
+				"acorn-dynamic-import": "^2.0.0",
+				"ajv": "^5.1.5",
+				"ajv-keywords": "^2.0.0",
+				"async": "^2.1.2",
+				"enhanced-resolve": "^3.4.0",
+				"escope": "^3.6.0",
+				"interpret": "^1.0.0",
+				"json-loader": "^0.5.4",
+				"json5": "^0.5.1",
+				"loader-runner": "^2.3.0",
+				"loader-utils": "^1.1.0",
+				"memory-fs": "~0.4.1",
+				"mkdirp": "~0.5.0",
+				"node-libs-browser": "^2.0.0",
+				"source-map": "^0.5.3",
+				"supports-color": "^4.2.1",
+				"tapable": "^0.2.7",
+				"uglifyjs-webpack-plugin": "^0.4.6",
+				"watchpack": "^1.4.0",
+				"webpack-sources": "^1.0.1",
+				"yargs": "^8.0.2"
 			},
 			"dependencies": {
 				"ajv-keywords": {
@@ -13951,9 +15357,9 @@
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 					"dev": true,
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wrap-ansi": "^2.0.0"
 					},
 					"dependencies": {
 						"string-width": {
@@ -13962,9 +15368,9 @@
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"dev": true,
 							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
 							}
 						}
 					}
@@ -13975,13 +15381,13 @@
 					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -13990,7 +15396,7 @@
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"load-json-file": {
@@ -13999,10 +15405,10 @@
 					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"strip-bom": "3.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"strip-bom": "^3.0.0"
 					},
 					"dependencies": {
 						"pify": {
@@ -14019,9 +15425,9 @@
 					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 					"dev": true,
 					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
 					}
 				},
 				"path-type": {
@@ -14030,7 +15436,7 @@
 					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
 					"dev": true,
 					"requires": {
-						"pify": "2.3.0"
+						"pify": "^2.0.0"
 					},
 					"dependencies": {
 						"pify": {
@@ -14047,9 +15453,9 @@
 					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "2.0.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "2.0.0"
+						"load-json-file": "^2.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^2.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -14058,8 +15464,8 @@
 					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
 					"dev": true,
 					"requires": {
-						"find-up": "2.1.0",
-						"read-pkg": "2.0.0"
+						"find-up": "^2.0.0",
+						"read-pkg": "^2.0.0"
 					}
 				},
 				"strip-bom": {
@@ -14074,7 +15480,7 @@
 					"integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
 					"dev": true,
 					"requires": {
-						"has-flag": "2.0.0"
+						"has-flag": "^2.0.0"
 					}
 				},
 				"which-module": {
@@ -14089,19 +15495,19 @@
 					"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"read-pkg-up": "2.0.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "7.0.0"
+						"camelcase": "^4.1.0",
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"read-pkg-up": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^7.0.0"
 					}
 				},
 				"yargs-parser": {
@@ -14110,7 +15516,7 @@
 					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					}
 				}
 			}
@@ -14121,11 +15527,11 @@
 			"integrity": "sha1-007++y7dp+HTtdvgcolRMhllFwk=",
 			"dev": true,
 			"requires": {
-				"memory-fs": "0.4.1",
-				"mime": "1.3.4",
-				"path-is-absolute": "1.0.1",
-				"range-parser": "1.2.0",
-				"time-stamp": "2.0.0"
+				"memory-fs": "~0.4.1",
+				"mime": "^1.3.4",
+				"path-is-absolute": "^1.0.0",
+				"range-parser": "^1.0.3",
+				"time-stamp": "^2.0.0"
 			}
 		},
 		"webpack-dev-server": {
@@ -14135,27 +15541,27 @@
 			"dev": true,
 			"requires": {
 				"ansi-html": "0.0.7",
-				"bonjour": "3.5.0",
-				"chokidar": "1.7.0",
-				"compression": "1.7.0",
-				"connect-history-api-fallback": "1.3.0",
-				"del": "3.0.0",
-				"express": "4.15.3",
-				"html-entities": "1.2.1",
-				"http-proxy-middleware": "0.17.4",
-				"internal-ip": "1.2.0",
-				"loglevel": "1.4.1",
+				"bonjour": "^3.5.0",
+				"chokidar": "^1.6.0",
+				"compression": "^1.5.2",
+				"connect-history-api-fallback": "^1.3.0",
+				"del": "^3.0.0",
+				"express": "^4.13.3",
+				"html-entities": "^1.2.0",
+				"http-proxy-middleware": "~0.17.4",
+				"internal-ip": "^1.2.0",
+				"loglevel": "^1.4.1",
 				"opn": "4.0.2",
-				"portfinder": "1.0.13",
-				"selfsigned": "1.9.1",
-				"serve-index": "1.9.0",
+				"portfinder": "^1.0.9",
+				"selfsigned": "^1.9.1",
+				"serve-index": "^1.7.2",
 				"sockjs": "0.3.18",
 				"sockjs-client": "1.1.4",
-				"spdy": "3.4.7",
-				"strip-ansi": "3.0.1",
-				"supports-color": "3.2.3",
-				"webpack-dev-middleware": "1.12.0",
-				"yargs": "6.6.0"
+				"spdy": "^3.4.1",
+				"strip-ansi": "^3.0.0",
+				"supports-color": "^3.1.1",
+				"webpack-dev-middleware": "^1.11.0",
+				"yargs": "^6.0.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -14170,9 +15576,9 @@
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 					"dev": true,
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
 				"has-flag": {
@@ -14187,7 +15593,7 @@
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"opn": {
@@ -14196,8 +15602,8 @@
 					"integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
 					"dev": true,
 					"requires": {
-						"object-assign": "4.1.1",
-						"pinkie-promise": "2.0.1"
+						"object-assign": "^4.0.1",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"string-width": {
@@ -14206,9 +15612,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"supports-color": {
@@ -14217,7 +15623,7 @@
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				},
 				"yargs": {
@@ -14226,19 +15632,19 @@
 					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
 					"dev": true,
 					"requires": {
-						"camelcase": "3.0.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "4.2.1"
+						"camelcase": "^3.0.0",
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^1.4.0",
+						"read-pkg-up": "^1.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^1.0.2",
+						"which-module": "^1.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^4.2.0"
 					}
 				},
 				"yargs-parser": {
@@ -14247,7 +15653,7 @@
 					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
 					"dev": true,
 					"requires": {
-						"camelcase": "3.0.0"
+						"camelcase": "^3.0.0"
 					}
 				}
 			}
@@ -14258,15 +15664,15 @@
 			"integrity": "sha512-HgNqQrXuCvV+S5qCgv9vrJfcldmxQ57KYZNMXVk842XFzunXQm/GbSM/Pwli7taOeiEX8ypFpSTGyMBRKc++rg==",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"glob": "7.1.2",
-				"mkdirp": "0.5.1",
-				"pify": "3.0.0",
+				"babel-code-frame": "^6.26.0",
+				"glob": "^7.0.5",
+				"mkdirp": "^0.5.1",
+				"pify": "^3.0.0",
 				"tmp": "0.0.29",
-				"uglify-es": "3.3.9",
-				"uglify-js": "3.3.16",
-				"webpack-sources": "1.0.1",
-				"worker-farm": "1.4.1"
+				"uglify-es": "^3.0.26",
+				"uglify-js": "^3.0.21",
+				"webpack-sources": "^1.0.0",
+				"worker-farm": "^1.3.1"
 			},
 			"dependencies": {
 				"commander": {
@@ -14287,7 +15693,7 @@
 					"integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
 					"dev": true,
 					"requires": {
-						"os-tmpdir": "1.0.2"
+						"os-tmpdir": "~1.0.1"
 					}
 				},
 				"uglify-es": {
@@ -14296,8 +15702,8 @@
 					"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
 					"dev": true,
 					"requires": {
-						"commander": "2.13.0",
-						"source-map": "0.6.1"
+						"commander": "~2.13.0",
+						"source-map": "~0.6.1"
 					}
 				},
 				"uglify-js": {
@@ -14306,8 +15712,8 @@
 					"integrity": "sha512-FMh5SRqJRGhv9BbaTffENIpDDQIoPDR8DBraunGORGhySArsXlw9++CN+BWzPBLpoI4RcSnpfGPnilTxWL3Vvg==",
 					"dev": true,
 					"requires": {
-						"commander": "2.15.1",
-						"source-map": "0.6.1"
+						"commander": "~2.15.0",
+						"source-map": "~0.6.1"
 					},
 					"dependencies": {
 						"commander": {
@@ -14326,8 +15732,8 @@
 			"integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
 			"dev": true,
 			"requires": {
-				"source-list-map": "2.0.0",
-				"source-map": "0.5.6"
+				"source-list-map": "^2.0.0",
+				"source-map": "~0.5.3"
 			}
 		},
 		"websocket-driver": {
@@ -14336,7 +15742,7 @@
 			"integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
 			"dev": true,
 			"requires": {
-				"websocket-extensions": "0.1.1"
+				"websocket-extensions": ">=0.1.1"
 			}
 		},
 		"websocket-extensions": {
@@ -14360,9 +15766,9 @@
 			"integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
 			"dev": true,
 			"requires": {
-				"lodash.sortby": "4.7.0",
-				"tr46": "1.0.1",
-				"webidl-conversions": "4.0.2"
+				"lodash.sortby": "^4.7.0",
+				"tr46": "^1.0.0",
+				"webidl-conversions": "^4.0.1"
 			}
 		},
 		"which": {
@@ -14371,7 +15777,7 @@
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
 			"dev": true,
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"which-module": {
@@ -14386,7 +15792,7 @@
 			"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
 			"dev": true,
 			"requires": {
-				"string-width": "1.0.2"
+				"string-width": "^1.0.2"
 			},
 			"dependencies": {
 				"is-fullwidth-code-point": {
@@ -14395,7 +15801,7 @@
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"string-width": {
@@ -14404,9 +15810,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				}
 			}
@@ -14429,8 +15835,8 @@
 			"integrity": "sha512-tgFAtgOYLPutkAyzgpS6VJFL5HY+0ui1Tvua+fITgz8ByaJTMFGtazR6xxQfwfiAcbwE+2fLG/K49wc2TfwCNw==",
 			"dev": true,
 			"requires": {
-				"errno": "0.1.4",
-				"xtend": "4.0.1"
+				"errno": "^0.1.4",
+				"xtend": "^4.0.1"
 			}
 		},
 		"wrap-ansi": {
@@ -14439,8 +15845,8 @@
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"dev": true,
 			"requires": {
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1"
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
 				"is-fullwidth-code-point": {
@@ -14449,7 +15855,7 @@
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"string-width": {
@@ -14458,9 +15864,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				}
 			}
@@ -14477,7 +15883,7 @@
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
 			"dev": true,
 			"requires": {
-				"mkdirp": "0.5.1"
+				"mkdirp": "^0.5.1"
 			}
 		},
 		"write-file-atomic": {
@@ -14486,9 +15892,9 @@
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"imurmurhash": "0.1.4",
-				"signal-exit": "3.0.2"
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"write-json-file": {
@@ -14497,12 +15903,12 @@
 			"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
 			"dev": true,
 			"requires": {
-				"detect-indent": "5.0.0",
-				"graceful-fs": "4.1.11",
-				"make-dir": "1.2.0",
-				"pify": "3.0.0",
-				"sort-keys": "2.0.0",
-				"write-file-atomic": "2.3.0"
+				"detect-indent": "^5.0.0",
+				"graceful-fs": "^4.1.2",
+				"make-dir": "^1.0.0",
+				"pify": "^3.0.0",
+				"sort-keys": "^2.0.0",
+				"write-file-atomic": "^2.0.0"
 			},
 			"dependencies": {
 				"detect-indent": {
@@ -14519,8 +15925,8 @@
 			"integrity": "sha1-AwqZlMyZk9JbTnWp8aGSNgcpHOk=",
 			"dev": true,
 			"requires": {
-				"sort-keys": "2.0.0",
-				"write-json-file": "2.3.0"
+				"sort-keys": "^2.0.0",
+				"write-json-file": "^2.2.0"
 			}
 		},
 		"ws": {
@@ -14529,8 +15935,8 @@
 			"integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
 			"dev": true,
 			"requires": {
-				"async-limiter": "1.0.0",
-				"safe-buffer": "5.1.1"
+				"async-limiter": "~1.0.0",
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"xtend": {
@@ -14557,20 +15963,20 @@
 			"integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
 			"dev": true,
 			"requires": {
-				"cliui": "3.2.0",
-				"decamelize": "1.2.0",
-				"get-caller-file": "1.0.2",
-				"lodash.assign": "4.2.0",
-				"os-locale": "1.4.0",
-				"read-pkg-up": "1.0.1",
-				"require-directory": "2.1.1",
-				"require-main-filename": "1.0.1",
-				"set-blocking": "2.0.0",
-				"string-width": "1.0.2",
-				"which-module": "1.0.0",
-				"window-size": "0.2.0",
-				"y18n": "3.2.1",
-				"yargs-parser": "2.4.1"
+				"cliui": "^3.2.0",
+				"decamelize": "^1.1.1",
+				"get-caller-file": "^1.0.1",
+				"lodash.assign": "^4.0.3",
+				"os-locale": "^1.4.0",
+				"read-pkg-up": "^1.0.1",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^1.0.1",
+				"set-blocking": "^2.0.0",
+				"string-width": "^1.0.1",
+				"which-module": "^1.0.0",
+				"window-size": "^0.2.0",
+				"y18n": "^3.2.1",
+				"yargs-parser": "^2.4.1"
 			},
 			"dependencies": {
 				"cliui": {
@@ -14579,9 +15985,9 @@
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 					"dev": true,
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -14590,7 +15996,7 @@
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"string-width": {
@@ -14599,9 +16005,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"window-size": {
@@ -14618,8 +16024,8 @@
 			"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
 			"dev": true,
 			"requires": {
-				"camelcase": "3.0.0",
-				"lodash.assign": "4.2.0"
+				"camelcase": "^3.0.0",
+				"lodash.assign": "^4.0.6"
 			},
 			"dependencies": {
 				"camelcase": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "eslint": "^4.19.1",
     "eslint-plugin-node": "^6.0.1",
     "husky": "^0.14.3",
-    "jest": "^22.4.3",
+    "jest": "^23.1.0",
     "lerna": "^2.9.0",
     "lint-staged": "^7.0.4",
     "prettier": "^1.11.1",

--- a/packages/babel-plugin-transform-jsxtreme-markdown/README.md
+++ b/packages/babel-plugin-transform-jsxtreme-markdown/README.md
@@ -1,7 +1,5 @@
 # @mapbox/babel-plugin-transform-jsxtreme-markdown
 
-🚧 🚧 **EXPERIMENTAL! WORK IN PROGRESS!** 🚧 🚧
-
 Transform Markdown interpolated with JS expressions and JSX elements into pure JSX, at compile time.
 
 Uses [jsxtreme-markdown](https://github.com/mapbox/jsxtreme-markdown/tree/master/packages/jsxtreme-markdown#readme) to compile the interpolated Markdown.

--- a/packages/jsxtreme-markdown-loader/CHANGELOG.md
+++ b/packages/jsxtreme-markdown-loader/CHANGELOG.md
@@ -1,5 +1,9 @@
 # jsxtreme-markdown-loader changelog
 
+## HEAD
+
+- Set `precompile: true` by default when calling `toComponentModule`.
+
 ## 0.7.0
 
 - Update `@mapbox/jsxtreme-markdown` with new method for stringifying JSX.

--- a/packages/jsxtreme-markdown-loader/README.md
+++ b/packages/jsxtreme-markdown-loader/README.md
@@ -1,7 +1,5 @@
 # @mapbox/jsxtreme-markdown-loader
 
-🚧 🚧 **EXPERIMENTAL! WORK IN PROGRESS!** 🚧 🚧
-
 Webpack loader to transform Markdown with interpolated JS and JSX into React components.
 
 Runs files through [the `toComponentModule` function of jsxtreme-markdown](https://github.com/mapbox/jsxtreme-markdown/tree/master/packages/jsxtreme-markdown#tocomponentmodule).
@@ -19,7 +17,8 @@ npm install @mapbox/jsxtreme-markdown-loader
 
 Follow the instructions for using [Webpack loaders](https://webpack.js.org/concepts/loaders/).
 
-⚠️  **The output of the default template includes JSX and ES2015 (`class`), so you should chain this loader with the [`babel-loader`](https://github.com/babel/babel-loader).**
+By default, the output of this loader is precompiled with Babel.
+You can bypass this step (and use your own compilation) by set the option `precompile: false`.
 
 ### options
 

--- a/packages/jsxtreme-markdown-loader/index.js
+++ b/packages/jsxtreme-markdown-loader/index.js
@@ -10,7 +10,7 @@ const defaultOptions = {
 
 module.exports = function(source) {
   let options = loaderUtils.getOptions(this) || {};
-  options = Object.assign(defaultOptions, options);
+  options = Object.assign({}, defaultOptions, options);
   if (options.getWrapper) {
     options = cloneDeep(options);
     options.wrapper = options.getWrapper(this.resource);

--- a/packages/jsxtreme-markdown-loader/index.js
+++ b/packages/jsxtreme-markdown-loader/index.js
@@ -4,8 +4,13 @@ const loaderUtils = require('loader-utils');
 const cloneDeep = require('lodash.clonedeep');
 const jsxtremeMarkdown = require('@mapbox/jsxtreme-markdown');
 
+const defaultOptions = {
+  precompile: true
+};
+
 module.exports = function(source) {
   let options = loaderUtils.getOptions(this) || {};
+  options = Object.assign(defaultOptions, options);
   if (options.getWrapper) {
     options = cloneDeep(options);
     options.wrapper = options.getWrapper(this.resource);

--- a/packages/jsxtreme-markdown-loader/test/index.test.js
+++ b/packages/jsxtreme-markdown-loader/test/index.test.js
@@ -23,8 +23,8 @@ describe('jsxtremeMarkdownLoader', () => {
   });
 
   afterEach(() => {
-    loaderUtils.getOptions.mockRestore();
-    jsxtremeMarkdown.toComponentModule.mockRestore();
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
   });
 
   test('gets options', () => {
@@ -38,7 +38,17 @@ describe('jsxtremeMarkdownLoader', () => {
     expect(jsxtremeMarkdown.toComponentModule).toHaveBeenCalledTimes(1);
     expect(jsxtremeMarkdown.toComponentModule).toHaveBeenCalledWith(
       'mockMarkdown',
-      mockOptions
+      { precompile: true }
+    );
+  });
+
+  test('turn off precompilation', () => {
+    loaderUtils.getOptions.mockReturnValue({ precompile: false });
+    mockContext.loader('mockMarkdown');
+    expect(jsxtremeMarkdown.toComponentModule).toHaveBeenCalledTimes(1);
+    expect(jsxtremeMarkdown.toComponentModule).toHaveBeenCalledWith(
+      'mockMarkdown',
+      { precompile: false }
     );
   });
 
@@ -61,11 +71,13 @@ describe('jsxtremeMarkdownLoader', () => {
     expect(getWrapper).toHaveBeenCalledTimes(1);
     expect(getWrapper).toHaveBeenCalledWith('mockResource');
     expect(jsxtremeMarkdown.toComponentModule).toHaveBeenCalledTimes(1);
-    expect(
-      jsxtremeMarkdown.toComponentModule
-    ).toHaveBeenCalledWith('mockMarkdown', {
-      wrapper: 'mockWrapper'
-    });
+    expect(jsxtremeMarkdown.toComponentModule).toHaveBeenCalledWith(
+      'mockMarkdown',
+      {
+        wrapper: 'mockWrapper',
+        precompile: true
+      }
+    );
   });
 
   test('result of getWrapper is independent for each invocation', () => {
@@ -84,7 +96,8 @@ describe('jsxtremeMarkdownLoader', () => {
     expect(jsxtremeMarkdown.toComponentModule.mock.calls[0]).toEqual([
       'mockMarkdownA',
       {
-        wrapper: 'AAA'
+        wrapper: 'AAA',
+        precompile: true
       }
     ]);
 
@@ -96,7 +109,8 @@ describe('jsxtremeMarkdownLoader', () => {
     expect(jsxtremeMarkdown.toComponentModule.mock.calls[1]).toEqual([
       'mockMarkdownB',
       {
-        wrapper: 'BBB'
+        wrapper: 'BBB',
+        precompile: true
       }
     ]);
 
@@ -108,7 +122,8 @@ describe('jsxtremeMarkdownLoader', () => {
     expect(jsxtremeMarkdown.toComponentModule.mock.calls[2]).toEqual([
       'mockMarkdownC',
       {
-        wrapper: 'CCC'
+        wrapper: 'CCC',
+        precompile: true
       }
     ]);
   });

--- a/packages/jsxtreme-markdown-loader/test/index.test.js
+++ b/packages/jsxtreme-markdown-loader/test/index.test.js
@@ -23,7 +23,6 @@ describe('jsxtremeMarkdownLoader', () => {
   });
 
   afterEach(() => {
-    jest.resetAllMocks();
     jest.restoreAllMocks();
   });
 

--- a/packages/jsxtreme-markdown/README.md
+++ b/packages/jsxtreme-markdown/README.md
@@ -1,7 +1,5 @@
 # @mapbox/jsxtreme-markdown
 
-🚧 🚧 **EXPERIMENTAL! WORK IN PROGRESS!** 🚧 🚧
-
 Transform **Markdown with interpolated JS expressions and JSX elements** into JSX or React component modules.
 
 This is the low-level, core module that takes one string (Markdown) and converts it to another string (JSX or a React component module).


### PR DESCRIPTION
Closes #46.

@kepta I'm having some kind of super frustrating misunderstanding with Jest. My new test (https://github.com/mapbox/jsxtreme-markdown/compare/no-babel-loader-requirement?expand=1#diff-9029312ac31b482691019824c023ddc2R45) changes the return value of a mock. But that mock is not getting restored between tests (or something?), so it ends up affecting the subsequent tests and they fail. I have no idea what's wrong. Do you see anything fishy? Any ideas?

(I tried updating Jest: no help.)