### PR TITLE
Minor fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,4 @@
 {
-	"name": "jsxtreme-markdown",
 	"requires": true,
 	"lockfileVersion": 1,
 	"dependencies": {
@@ -7,7 +6,6 @@
 			"version": "7.0.0-beta.42",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.42.tgz",
 			"integrity": "sha512-L8i94FLSyaLQpRfDo/qqSm8Ndb44zMtXParXo0MebJICG1zoCCL4+GkzUOlB4BNTRSXXQdb3feam/qw7bKPipQ==",
-			"dev": true,
 			"requires": {
 				"@babel/highlight": "7.0.0-beta.42"
 			}
@@ -16,7 +14,6 @@
 			"version": "7.0.0-beta.42",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.42.tgz",
 			"integrity": "sha512-X3Ur/A/lIbbP8W0pmwgqtDXIxhQmxPaiwY9SKP7kF9wvZfjZRwMvbJE92ozUhF3UDK3DCKaV7oGqmI1rP/zqWA==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
@@ -27,7 +24,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -36,7 +32,6 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -46,14 +41,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"supports-color": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -64,7 +57,6 @@
 			"version": "0.21.2",
 			"resolved": "https://registry.npmjs.org/@mapbox/assembly/-/assembly-0.21.2.tgz",
 			"integrity": "sha512-wbJpZFpqj07VIDnL1ZWnPdf5hl3rfCBYRAh5U+pb12OHwsgnAta/VTxwfHabopzDAh4AuHlhsNA/YEV4x4iVdw==",
-			"dev": true,
 			"requires": {
 				"autoprefixer": "^8.2.0",
 				"concat-with-sourcemaps": "^1.0.4",
@@ -90,7 +82,6 @@
 					"version": "8.0.1",
 					"resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
 					"integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
-					"dev": true,
 					"requires": {
 						"array-union": "^1.0.1",
 						"dir-glob": "^2.0.0",
@@ -104,20 +95,17 @@
 				"indent-string": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-					"dev": true
+					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"uglify-js": {
 					"version": "3.3.20",
 					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.20.tgz",
 					"integrity": "sha512-WpLkWCf9sGvGZnIvBV0PNID9BATQNT/IXKAmqegfKzIPcTmTV3FP8NQpoogQkt/Y402x2sOFdaHUmqFY9IZp+g==",
-					"dev": true,
 					"requires": {
 						"commander": "~2.15.0",
 						"source-map": "~0.6.1"
@@ -125,21 +113,32 @@
 				}
 			}
 		},
+		"@mapbox/hast-util-table-cell-style": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@mapbox/hast-util-table-cell-style/-/hast-util-table-cell-style-0.1.3.tgz",
+			"integrity": "sha512-QsEsh5YaDvHoMQ2YHdvZy2iDnU3GgKVBTcHf6cILyoWDZtPSdlG444pL/ioPYO/GpXSfODBb9sefEetfC4v9oA==",
+			"requires": {
+				"unist-util-visit": "^1.3.0"
+			}
+		},
 		"@mrmlnc/readdir-enhanced": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
 			"integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
-			"dev": true,
 			"requires": {
 				"call-me-maybe": "^1.0.1",
 				"glob-to-regexp": "^0.3.0"
 			}
 		},
+		"@types/node": {
+			"version": "10.3.3",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.3.tgz",
+			"integrity": "sha512-/gwCgiI2e9RzzZTKbl+am3vgNqOt7a9fJ/uxv4SqYKxenoEDNVU3KZEadlpusWhQI0A0dOrZ0T68JYKVjzmgdQ=="
+		},
 		"JSONStream": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
 			"integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
-			"dev": true,
 			"requires": {
 				"jsonparse": "^1.2.0",
 				"through": ">=2.2.7 <3"
@@ -148,14 +147,17 @@
 		"abab": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
-			"dev": true
+			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
+		},
+		"abbrev": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
 		},
 		"accepts": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
 			"integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
-			"dev": true,
 			"requires": {
 				"mime-types": "~2.1.11",
 				"negotiator": "0.6.1"
@@ -164,14 +166,12 @@
 		"acorn": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
-			"integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
-			"dev": true
+			"integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw=="
 		},
 		"acorn-dynamic-import": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
 			"integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
-			"dev": true,
 			"requires": {
 				"acorn": "^4.0.3"
 			},
@@ -179,8 +179,7 @@
 				"acorn": {
 					"version": "4.0.13",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-					"dev": true
+					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
 				}
 			}
 		},
@@ -188,7 +187,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
 			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
-			"dev": true,
 			"requires": {
 				"acorn": "^5.0.0"
 			}
@@ -197,7 +195,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-			"dev": true,
 			"requires": {
 				"acorn": "^3.0.4"
 			},
@@ -205,22 +202,19 @@
 				"acorn": {
 					"version": "3.3.0",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-					"dev": true
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
 				}
 			}
 		},
 		"add-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
-			"integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
-			"dev": true
+			"integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo="
 		},
 		"ajv": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
 			"integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
-			"dev": true,
 			"requires": {
 				"co": "^4.6.0",
 				"fast-deep-equal": "^1.0.0",
@@ -231,14 +225,12 @@
 		"ajv-keywords": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
-			"dev": true
+			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
 		},
 		"align-text": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2",
 				"longest": "^1.0.1",
@@ -248,44 +240,37 @@
 		"amdefine": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-			"dev": true
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
 		},
 		"ansi-escapes": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
-			"dev": true
+			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
 		},
 		"ansi-html": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
-			"integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
-			"dev": true
+			"integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-			"dev": true
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 		},
 		"ansi-styles": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-			"dev": true
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
 		},
 		"any-observable": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.2.0.tgz",
-			"integrity": "sha1-xnhwBYADV5AJCD9UrAq6+1wz0kI=",
-			"dev": true
+			"integrity": "sha1-xnhwBYADV5AJCD9UrAq6+1wz0kI="
 		},
 		"anymatch": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
 			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-			"dev": true,
 			"requires": {
 				"micromatch": "^2.1.5",
 				"normalize-path": "^2.0.0"
@@ -295,7 +280,6 @@
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-					"dev": true,
 					"requires": {
 						"remove-trailing-separator": "^1.0.1"
 					}
@@ -305,14 +289,12 @@
 		"app-root-path": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
-			"integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y=",
-			"dev": true
+			"integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y="
 		},
 		"append-transform": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
 			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
-			"dev": true,
 			"requires": {
 				"default-require-extensions": "^1.0.0"
 			}
@@ -320,14 +302,12 @@
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-			"dev": true
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
 		},
 		"are-we-there-yet": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
 			"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-			"dev": true,
 			"requires": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
@@ -337,7 +317,6 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
 			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -346,7 +325,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-			"dev": true,
 			"requires": {
 				"arr-flatten": "^1.0.1"
 			}
@@ -354,44 +332,37 @@
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-			"dev": true
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
 		},
 		"arr-union": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-			"dev": true
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
 		},
 		"array-equal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
-			"dev": true
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
 		},
 		"array-find-index": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-			"dev": true
+			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
 		},
 		"array-flatten": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
-			"integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=",
-			"dev": true
+			"integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY="
 		},
 		"array-ify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
-			"dev": true
+			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4="
 		},
 		"array-union": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-			"dev": true,
 			"requires": {
 				"array-uniq": "^1.0.1"
 			}
@@ -399,32 +370,32 @@
 		"array-uniq": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-			"dev": true
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
 		},
 		"array-unique": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-			"dev": true
+			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
 		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-			"dev": true
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+		},
+		"asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
 		"asn1": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-			"dev": true
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
 		},
 		"asn1.js": {
 			"version": "4.9.1",
 			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
 			"integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.0.0",
 				"inherits": "^2.0.1",
@@ -435,7 +406,6 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
 			"integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
-			"dev": true,
 			"requires": {
 				"util": "0.10.3"
 			}
@@ -443,26 +413,22 @@
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-			"dev": true
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
 		"assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-			"dev": true
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
 		},
 		"astral-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
-			"dev": true
+			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
 		},
 		"async": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
 			"integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-			"dev": true,
 			"requires": {
 				"lodash": "^4.14.0"
 			}
@@ -470,32 +436,27 @@
 		"async-each": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
-			"dev": true
+			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
 		},
 		"async-limiter": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
-			"dev": true
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
 		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-			"dev": true
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
 		"atob": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
-			"integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10=",
-			"dev": true
+			"integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10="
 		},
 		"autoprefixer": {
 			"version": "8.2.0",
 			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.2.0.tgz",
 			"integrity": "sha512-xBVQpGAcSNNS1PBnEfT+F9VF8ZJeoKZ121I3OVQ0n1F0SqVuj4oLI6yFeEviPV8Z/GjoqBRXcYis0oSS8zjNEg==",
-			"dev": true,
 			"requires": {
 				"browserslist": "^3.2.0",
 				"caniuse-lite": "^1.0.30000817",
@@ -509,7 +470,6 @@
 					"version": "3.2.4",
 					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.4.tgz",
 					"integrity": "sha512-Dwe62y/fNAcMfknzGJnkh7feISrrN0SmRvMFozb+Y2+qg7rfTIH5MS8yHzaIXcEWl8fPeIcdhZNQi1Lux+7dlg==",
-					"dev": true,
 					"requires": {
 						"caniuse-lite": "^1.0.30000821",
 						"electron-to-chromium": "^1.3.41"
@@ -518,34 +478,29 @@
 				"caniuse-lite": {
 					"version": "1.0.30000827",
 					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000827.tgz",
-					"integrity": "sha512-j9Q9hP5AhqOARNP6fLdctr3XrGhF921sBSycudf4E+8RCWpFT3rJdTfp/5o8LDp6p0NJTpYWEpBFiM+QEDzA6g==",
-					"dev": true
+					"integrity": "sha512-j9Q9hP5AhqOARNP6fLdctr3XrGhF921sBSycudf4E+8RCWpFT3rJdTfp/5o8LDp6p0NJTpYWEpBFiM+QEDzA6g=="
 				},
 				"electron-to-chromium": {
 					"version": "1.3.42",
 					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.42.tgz",
-					"integrity": "sha1-lcM78B0MxAVVauyJn+Yf1NduoPk=",
-					"dev": true
+					"integrity": "sha1-lcM78B0MxAVVauyJn+Yf1NduoPk="
 				}
 			}
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-			"dev": true
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
 		},
 		"aws4": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-			"dev": true
+			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-			"dev": true,
 			"requires": {
 				"chalk": "^1.1.3",
 				"esutils": "^2.0.2",
@@ -556,7 +511,6 @@
 			"version": "6.26.3",
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
 			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-			"dev": true,
 			"requires": {
 				"babel-code-frame": "^6.26.0",
 				"babel-generator": "^6.26.0",
@@ -583,7 +537,6 @@
 					"version": "6.26.0",
 					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 					"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-					"dev": true,
 					"requires": {
 						"core-js": "^2.4.0",
 						"regenerator-runtime": "^0.11.0"
@@ -593,7 +546,6 @@
 					"version": "6.26.0",
 					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
 					"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-					"dev": true,
 					"requires": {
 						"babel-runtime": "^6.26.0",
 						"babel-traverse": "^6.26.0",
@@ -606,7 +558,6 @@
 					"version": "6.26.0",
 					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
 					"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-					"dev": true,
 					"requires": {
 						"babel-code-frame": "^6.26.0",
 						"babel-messages": "^6.23.0",
@@ -623,7 +574,6 @@
 					"version": "6.26.0",
 					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
 					"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-					"dev": true,
 					"requires": {
 						"babel-runtime": "^6.26.0",
 						"esutils": "^2.0.2",
@@ -635,7 +585,6 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -643,20 +592,17 @@
 				"private": {
 					"version": "0.1.8",
 					"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-					"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-					"dev": true
+					"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
 				},
 				"regenerator-runtime": {
 					"version": "0.11.1",
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-					"dev": true
+					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
 			}
 		},
@@ -664,7 +610,6 @@
 			"version": "6.26.1",
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-			"dev": true,
 			"requires": {
 				"babel-messages": "^6.23.0",
 				"babel-runtime": "^6.26.0",
@@ -680,7 +625,6 @@
 					"version": "6.26.0",
 					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 					"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-					"dev": true,
 					"requires": {
 						"core-js": "^2.4.0",
 						"regenerator-runtime": "^0.11.0"
@@ -690,7 +634,6 @@
 					"version": "6.26.0",
 					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
 					"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-					"dev": true,
 					"requires": {
 						"babel-runtime": "^6.26.0",
 						"esutils": "^2.0.2",
@@ -701,14 +644,12 @@
 				"regenerator-runtime": {
 					"version": "0.11.1",
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-					"dev": true
+					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
 			}
 		},
@@ -716,7 +657,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-			"dev": true,
 			"requires": {
 				"babel-helper-explode-assignable-expression": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -727,7 +667,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.24.1.tgz",
 			"integrity": "sha1-CteRfjPI11HmRtrKTnfMGTd9LLw=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1",
@@ -738,7 +677,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -750,7 +688,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
 			"integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
-			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -762,7 +699,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-traverse": "^6.24.1",
@@ -773,7 +709,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-			"dev": true,
 			"requires": {
 				"babel-helper-get-function-arity": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -786,7 +721,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -796,7 +730,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -806,7 +739,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -816,7 +748,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
 			"integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1",
@@ -827,7 +758,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -840,7 +770,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-			"dev": true,
 			"requires": {
 				"babel-helper-optimise-call-expression": "^6.24.1",
 				"babel-messages": "^6.23.0",
@@ -854,7 +783,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-template": "^6.24.1"
@@ -864,7 +792,6 @@
 			"version": "23.0.1",
 			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.0.1.tgz",
 			"integrity": "sha1-u6079SP7IC2gXtCmVAtIyE7tE6Y=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-istanbul": "^4.1.6",
 				"babel-preset-jest": "^23.0.1"
@@ -874,7 +801,6 @@
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.4.tgz",
 			"integrity": "sha512-/hbyEvPzBJuGpk9o80R0ZyTej6heEOr59GoEUtn8qFKbnx4cJm9FWES6J/iv644sYgrtVw9JJQkjaLW/bqb5gw==",
-			"dev": true,
 			"requires": {
 				"find-cache-dir": "^1.0.0",
 				"loader-utils": "^1.0.2",
@@ -885,7 +811,6 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -894,7 +819,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -903,7 +827,6 @@
 			"version": "4.1.6",
 			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
 			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-object-rest-spread": "^6.13.0",
 				"find-up": "^2.1.0",
@@ -914,50 +837,42 @@
 		"babel-plugin-jest-hoist": {
 			"version": "23.0.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.0.1.tgz",
-			"integrity": "sha1-6qEclkVjrqnCG+zvK994U/fzwUg=",
-			"dev": true
+			"integrity": "sha1-6qEclkVjrqnCG+zvK994U/fzwUg="
 		},
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-			"dev": true
+			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-			"dev": true
+			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
 		},
 		"babel-plugin-syntax-flow": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
-			"dev": true
+			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
 		},
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
-			"dev": true
+			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
-			"dev": true
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
 		},
 		"babel-plugin-syntax-trailing-function-commas": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
-			"dev": true
+			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
 		},
 		"babel-plugin-transform-async-to-generator": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "^6.24.1",
 				"babel-plugin-syntax-async-functions": "^6.8.0",
@@ -968,7 +883,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -977,7 +891,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -986,7 +899,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
 			"integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-template": "^6.24.1",
@@ -999,7 +911,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-			"dev": true,
 			"requires": {
 				"babel-helper-define-map": "^6.24.1",
 				"babel-helper-function-name": "^6.24.1",
@@ -1016,7 +927,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-template": "^6.24.1"
@@ -1026,7 +936,6 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -1035,7 +944,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -1045,7 +953,6 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -1054,7 +961,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -1065,7 +971,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -1074,7 +979,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -1085,7 +989,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
 			"integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-transform-strict-mode": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -1097,7 +1000,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -1108,7 +1010,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -1119,7 +1020,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-			"dev": true,
 			"requires": {
 				"babel-helper-replace-supers": "^6.24.1",
 				"babel-runtime": "^6.22.0"
@@ -1129,7 +1029,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-			"dev": true,
 			"requires": {
 				"babel-helper-call-delegate": "^6.24.1",
 				"babel-helper-get-function-arity": "^6.24.1",
@@ -1143,7 +1042,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -1153,7 +1051,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -1162,7 +1059,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-			"dev": true,
 			"requires": {
 				"babel-helper-regex": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -1173,7 +1069,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -1182,7 +1077,6 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -1191,7 +1085,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-			"dev": true,
 			"requires": {
 				"babel-helper-regex": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -1202,7 +1095,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-			"dev": true,
 			"requires": {
 				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
 				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
@@ -1213,7 +1105,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-flow": "^6.18.0",
 				"babel-runtime": "^6.22.0"
@@ -1223,7 +1114,6 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
 			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -1232,7 +1122,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
 			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
-			"dev": true,
 			"requires": {
 				"babel-helper-builder-react-jsx": "^6.24.1",
 				"babel-plugin-syntax-jsx": "^6.8.0",
@@ -1243,7 +1132,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
 			"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "^6.8.0",
 				"babel-runtime": "^6.22.0"
@@ -1253,7 +1141,6 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
 			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "^6.8.0",
 				"babel-runtime": "^6.22.0"
@@ -1263,7 +1150,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
 			"integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg=",
-			"dev": true,
 			"requires": {
 				"regenerator-transform": "0.9.11"
 			}
@@ -1272,7 +1158,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -1282,7 +1167,6 @@
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
 			"integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
-			"dev": true,
 			"requires": {
 				"babel-plugin-check-es2015-constants": "^6.22.0",
 				"babel-plugin-syntax-trailing-function-commas": "^6.22.0",
@@ -1320,7 +1204,6 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
 			"integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-transform-flow-strip-types": "^6.22.0"
 			}
@@ -1329,7 +1212,6 @@
 			"version": "23.0.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.0.1.tgz",
 			"integrity": "sha1-YxzFRcbPAhlDATvK8i9F2H/mIZg=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-jest-hoist": "^23.0.1",
 				"babel-plugin-syntax-object-rest-spread": "^6.13.0"
@@ -1339,7 +1221,6 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
 			"integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
-			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "^6.3.13",
 				"babel-plugin-transform-react-display-name": "^6.23.0",
@@ -1353,7 +1234,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-			"dev": true,
 			"requires": {
 				"babel-core": "^6.26.0",
 				"babel-runtime": "^6.26.0",
@@ -1368,7 +1248,6 @@
 					"version": "6.26.0",
 					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 					"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-					"dev": true,
 					"requires": {
 						"core-js": "^2.4.0",
 						"regenerator-runtime": "^0.11.0"
@@ -1377,14 +1256,12 @@
 				"core-js": {
 					"version": "2.5.7",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-					"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
-					"dev": true
+					"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
 				},
 				"regenerator-runtime": {
 					"version": "0.11.1",
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-					"dev": true
+					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
 				}
 			}
 		},
@@ -1392,7 +1269,6 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
 			"integrity": "sha1-M7mOql1IK7AajRqmtDetKwGuxBw=",
-			"dev": true,
 			"requires": {
 				"core-js": "^2.4.0",
 				"regenerator-runtime": "^0.10.0"
@@ -1402,7 +1278,6 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
 			"integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-traverse": "^6.25.0",
@@ -1415,7 +1290,6 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
 			"integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
-			"dev": true,
 			"requires": {
 				"babel-code-frame": "^6.22.0",
 				"babel-messages": "^6.23.0",
@@ -1432,7 +1306,6 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
 			"integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"esutils": "^2.0.2",
@@ -1443,20 +1316,22 @@
 		"babylon": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-			"dev": true
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+		},
+		"bail": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
+			"integrity": "sha512-1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"base": {
 			"version": "0.11.2",
 			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-			"dev": true,
 			"requires": {
 				"cache-base": "^1.0.1",
 				"class-utils": "^0.3.5",
@@ -1471,7 +1346,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -1479,28 +1353,24 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
 		},
 		"base64-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-			"integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
-			"dev": true
+			"integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
 		},
 		"batch": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-			"integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
-			"dev": true
+			"integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
 			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
@@ -1509,26 +1379,32 @@
 		"big.js": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
-			"integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg=",
-			"dev": true
+			"integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg="
 		},
 		"binary-extensions": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.9.0.tgz",
-			"integrity": "sha1-ZlBsFs5vTWkopbPNajPKQelB43s=",
-			"dev": true
+			"integrity": "sha1-ZlBsFs5vTWkopbPNajPKQelB43s="
+		},
+		"block-elements": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/block-elements/-/block-elements-1.2.0.tgz",
+			"integrity": "sha1-jgTMq2OMfiWW9QZftsHHUYyQWl0="
+		},
+		"bluebird": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
 		},
 		"bn.js": {
 			"version": "4.11.7",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.7.tgz",
-			"integrity": "sha512-LxFiV5mefv0ley0SzqkOPR1bC4EbpPx8LkOz5vMe/Yi15t5hzwgO/G+tc7wOtL4PZTYjwHu8JnEiSLumuSjSfA==",
-			"dev": true
+			"integrity": "sha512-LxFiV5mefv0ley0SzqkOPR1bC4EbpPx8LkOz5vMe/Yi15t5hzwgO/G+tc7wOtL4PZTYjwHu8JnEiSLumuSjSfA=="
 		},
 		"bonjour": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
 			"integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
-			"dev": true,
 			"requires": {
 				"array-flatten": "^2.1.0",
 				"deep-equal": "^1.0.1",
@@ -1541,14 +1417,12 @@
 		"boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-			"dev": true
+			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
 		},
 		"boom": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
 			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-			"dev": true,
 			"requires": {
 				"hoek": "4.x.x"
 			}
@@ -1557,7 +1431,6 @@
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
 			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -1567,7 +1440,6 @@
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-			"dev": true,
 			"requires": {
 				"expand-range": "^1.8.1",
 				"preserve": "^0.2.0",
@@ -1577,20 +1449,17 @@
 		"brorand": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
-			"dev": true
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
 		},
 		"browser-process-hrtime": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
-			"integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
-			"dev": true
+			"integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44="
 		},
 		"browser-resolve": {
 			"version": "1.11.2",
 			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
 			"integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
-			"dev": true,
 			"requires": {
 				"resolve": "1.1.7"
 			},
@@ -1598,8 +1467,7 @@
 				"resolve": {
 					"version": "1.1.7",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-					"dev": true
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
 				}
 			}
 		},
@@ -1607,7 +1475,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
 			"integrity": "sha1-Xncl297x/Vkw1OurSFZ85FHEigo=",
-			"dev": true,
 			"requires": {
 				"buffer-xor": "^1.0.2",
 				"cipher-base": "^1.0.0",
@@ -1620,7 +1487,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
 			"integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
-			"dev": true,
 			"requires": {
 				"browserify-aes": "^1.0.4",
 				"browserify-des": "^1.0.0",
@@ -1631,7 +1497,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
 			"integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
-			"dev": true,
 			"requires": {
 				"cipher-base": "^1.0.1",
 				"des.js": "^1.0.0",
@@ -1642,7 +1507,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.0",
 				"randombytes": "^2.0.1"
@@ -1652,7 +1516,6 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
 			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.1",
 				"browserify-rsa": "^4.0.0",
@@ -1667,7 +1530,6 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
 			"integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
-			"dev": true,
 			"requires": {
 				"pako": "~0.2.0"
 			}
@@ -1676,7 +1538,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.3.0.tgz",
 			"integrity": "sha512-jDr9Mea+n+FwI+kR0ce7rXCFBoM7hbL80G/th7oPxuNSK4V5J3LPMHB5vykjeI2h7fgSihBbSdoJPmzUC0606Q==",
-			"dev": true,
 			"requires": {
 				"caniuse-lite": "^1.0.30000710",
 				"electron-to-chromium": "^1.3.17"
@@ -1686,7 +1547,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
 			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
-			"dev": true,
 			"requires": {
 				"node-int64": "^0.4.0"
 			}
@@ -1694,50 +1554,42 @@
 		"buffer-from": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-			"integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
-			"dev": true
+			"integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
 		},
 		"buffer-indexof": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.0.tgz",
-			"integrity": "sha1-9U9kfE9OJSKLqmVqLlfkPV8nCYI=",
-			"dev": true
+			"integrity": "sha1-9U9kfE9OJSKLqmVqLlfkPV8nCYI="
 		},
 		"buffer-xor": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
-			"dev": true
+			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
 		},
 		"builtin-modules": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-			"dev": true
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
 		},
 		"builtin-status-codes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
-			"dev": true
+			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
 		},
 		"byline": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
-			"dev": true
+			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
 		},
 		"bytes": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-2.5.0.tgz",
-			"integrity": "sha1-TJQj6i0lLCcMQbK97+/5u2tiwGo=",
-			"dev": true
+			"integrity": "sha1-TJQj6i0lLCcMQbK97+/5u2tiwGo="
 		},
 		"cache-base": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-			"dev": true,
 			"requires": {
 				"collection-visit": "^1.0.0",
 				"component-emitter": "^1.2.1",
@@ -1753,22 +1605,19 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
 		},
 		"call-me-maybe": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
-			"dev": true
+			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
 		},
 		"caller-path": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-			"dev": true,
 			"requires": {
 				"callsites": "^0.2.0"
 			}
@@ -1776,20 +1625,31 @@
 		"callsites": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-			"dev": true
+			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
+		},
+		"camel-case": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+			"integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+			"requires": {
+				"no-case": "^2.2.0",
+				"upper-case": "^1.1.1"
+			}
 		},
 		"camelcase": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-			"dev": true
+			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+		},
+		"camelcase-css": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-1.0.1.tgz",
+			"integrity": "sha1-FXxCOCZfXPlKHf/ehkRlUsvz9wU="
 		},
 		"camelcase-keys": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-			"dev": true,
 			"requires": {
 				"camelcase": "^2.0.0",
 				"map-obj": "^1.0.0"
@@ -1798,22 +1658,19 @@
 				"camelcase": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-					"dev": true
+					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
 				}
 			}
 		},
 		"caniuse-lite": {
 			"version": "1.0.30000710",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000710.tgz",
-			"integrity": "sha1-HCSb98amEWHJsQkG462fpbZ2GvE=",
-			"dev": true
+			"integrity": "sha1-HCSb98amEWHJsQkG462fpbZ2GvE="
 		},
 		"capture-exit": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
 			"integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
-			"dev": true,
 			"requires": {
 				"rsvp": "^3.3.3"
 			}
@@ -1821,20 +1678,17 @@
 		"capture-stack-trace": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-			"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
-			"dev": true
+			"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
 		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-			"dev": true
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
 		"center-align": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
 			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-			"dev": true,
 			"requires": {
 				"align-text": "^0.1.3",
 				"lazy-cache": "^1.0.3"
@@ -1844,7 +1698,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "^2.2.1",
 				"escape-string-regexp": "^1.0.2",
@@ -1853,17 +1706,35 @@
 				"supports-color": "^2.0.0"
 			}
 		},
+		"character-entities": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.2.tgz",
+			"integrity": "sha512-sMoHX6/nBiy3KKfC78dnEalnpn0Az0oSNvqUWYTtYrhRI5iUIYsROU48G+E+kMFQzqXaJ8kHJZ85n7y6/PHgwQ=="
+		},
+		"character-entities-html4": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.2.tgz",
+			"integrity": "sha512-sIrXwyna2+5b0eB9W149izTPJk/KkJTg6mEzDGibwBUkyH1SbDa+nf515Ppdi3MaH35lW0JFJDWeq9Luzes1Iw=="
+		},
+		"character-entities-legacy": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz",
+			"integrity": "sha512-9NB2VbXtXYWdXzqrvAHykE/f0QJxzaKIpZ5QzNZrrgQ7Iyxr2vnfS8fCBNVW9nUEZE0lo57nxKRqnzY/dKrwlA=="
+		},
+		"character-reference-invalid": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz",
+			"integrity": "sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ=="
+		},
 		"chardet": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-			"dev": true
+			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
 		},
 		"cheerio": {
 			"version": "0.22.0",
 			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
 			"integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
-			"dev": true,
 			"requires": {
 				"css-select": "~1.2.0",
 				"dom-serializer": "~0.1.0",
@@ -1887,7 +1758,6 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
 					"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-					"dev": true,
 					"requires": {
 						"boolbase": "~1.0.0",
 						"css-what": "2.1",
@@ -1901,7 +1771,6 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
 			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-			"dev": true,
 			"requires": {
 				"anymatch": "^1.3.0",
 				"async-each": "^1.0.0",
@@ -1917,14 +1786,12 @@
 		"ci-info": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz",
-			"integrity": "sha1-3FKF8rTiUYIWg2gcOBwziPRuxTQ=",
-			"dev": true
+			"integrity": "sha1-3FKF8rTiUYIWg2gcOBwziPRuxTQ="
 		},
 		"cipher-base": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
 			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
@@ -1933,14 +1800,12 @@
 		"circular-json": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-			"dev": true
+			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
 		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"define-property": "^0.2.5",
@@ -1952,7 +1817,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -1961,7 +1825,6 @@
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
@@ -1970,7 +1833,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -1981,7 +1843,6 @@
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
@@ -1990,7 +1851,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -2001,7 +1861,6 @@
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^0.1.6",
 						"is-data-descriptor": "^0.1.4",
@@ -2011,14 +1870,12 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				},
 				"kind-of": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-					"dev": true
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 				}
 			}
 		},
@@ -2026,7 +1883,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-			"dev": true,
 			"requires": {
 				"restore-cursor": "^2.0.0"
 			}
@@ -2034,14 +1890,12 @@
 		"cli-spinners": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
-			"integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
-			"dev": true
+			"integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw="
 		},
 		"cli-truncate": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
 			"integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
-			"dev": true,
 			"requires": {
 				"slice-ansi": "0.0.4",
 				"string-width": "^1.0.1"
@@ -2051,7 +1905,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -2059,14 +1912,12 @@
 				"slice-ansi": {
 					"version": "0.0.4",
 					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-					"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-					"dev": true
+					"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
 				},
 				"string-width": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -2078,14 +1929,12 @@
 		"cli-width": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-			"dev": true
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
 		},
 		"cliui": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
 			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-			"dev": true,
 			"requires": {
 				"center-align": "^0.1.1",
 				"right-align": "^0.1.1",
@@ -2095,22 +1944,19 @@
 				"wordwrap": {
 					"version": "0.0.2",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-					"dev": true
+					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
 				}
 			}
 		},
 		"clone": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-			"dev": true
+			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
 		},
 		"cmd-shim": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
 			"integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"mkdirp": "~0.5.0"
@@ -2119,14 +1965,12 @@
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-			"dev": true
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
 		},
 		"coa": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/coa/-/coa-2.0.1.tgz",
 			"integrity": "sha512-5wfTTO8E2/ja4jFSxePXlG5nRu5bBtL/r1HCIpJW/lzT6yDtKl0u0Z4o/Vpz32IpKmBn7HerheEZQgA9N2DarQ==",
-			"dev": true,
 			"requires": {
 				"q": "^1.1.2"
 			}
@@ -2134,14 +1978,17 @@
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-			"dev": true
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+		},
+		"collapse-white-space": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.4.tgz",
+			"integrity": "sha512-YfQ1tAUZm561vpYD+5eyWN8+UsceQbSrqqlc/6zDY2gtAE+uZLSdkkovhnGpmCThsvKBFakq4EdY/FF93E8XIw=="
 		},
 		"collection-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-			"dev": true,
 			"requires": {
 				"map-visit": "^1.0.0",
 				"object-visit": "^1.0.0"
@@ -2151,7 +1998,6 @@
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
 			"integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-			"dev": true,
 			"requires": {
 				"color-name": "^1.1.1"
 			}
@@ -2159,20 +2005,17 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"colors": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-			"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-			"dev": true
+			"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
 		},
 		"columnify": {
 			"version": "1.5.4",
 			"resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
 			"integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
-			"dev": true,
 			"requires": {
 				"strip-ansi": "^3.0.0",
 				"wcwidth": "^1.0.0"
@@ -2182,34 +2025,37 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
 			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-			"dev": true,
 			"requires": {
 				"delayed-stream": "~1.0.0"
+			}
+		},
+		"comma-separated-tokens": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.5.tgz",
+			"integrity": "sha512-Cg90/fcK93n0ecgYTAz1jaA3zvnQ0ExlmKY1rdbyHqAx6BHxwoJc+J7HDu0iuQ7ixEs1qaa+WyQ6oeuBpYP1iA==",
+			"requires": {
+				"trim": "0.0.1"
 			}
 		},
 		"command-join": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/command-join/-/command-join-2.0.0.tgz",
-			"integrity": "sha1-Uui5hPSHLZUv8b3IuYOX0nxxRM8=",
-			"dev": true
+			"integrity": "sha1-Uui5hPSHLZUv8b3IuYOX0nxxRM8="
 		},
 		"commander": {
 			"version": "2.15.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-			"dev": true
+			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
 		},
 		"commondir": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-			"dev": true
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
 		},
 		"compare-func": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
 			"integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
-			"dev": true,
 			"requires": {
 				"array-ify": "^1.0.0",
 				"dot-prop": "^3.0.0"
@@ -2218,20 +2064,17 @@
 		"compare-versions": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.2.1.tgz",
-			"integrity": "sha512-2y2nHcopMG/NAyk6vWXlLs86XeM9sik4jmx1tKIgzMi9/RQ2eo758RGpxQO3ErihHmg0RlQITPqgz73y6s7quA==",
-			"dev": true
+			"integrity": "sha512-2y2nHcopMG/NAyk6vWXlLs86XeM9sik4jmx1tKIgzMi9/RQ2eo758RGpxQO3ErihHmg0RlQITPqgz73y6s7quA=="
 		},
 		"component-emitter": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-			"dev": true
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
 		},
 		"compressible": {
 			"version": "2.0.11",
 			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz",
 			"integrity": "sha1-FnGKdd4oPtjmBAQWJaIGRYZ5fYo=",
-			"dev": true,
 			"requires": {
 				"mime-db": ">= 1.29.0 < 2"
 			}
@@ -2240,7 +2083,6 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.0.tgz",
 			"integrity": "sha1-AwyfGY8WQ6BX13anOOki2kNzAS0=",
-			"dev": true,
 			"requires": {
 				"accepts": "~1.3.3",
 				"bytes": "2.5.0",
@@ -2254,14 +2096,12 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"inherits": "^2.0.3",
@@ -2273,7 +2113,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.5.tgz",
 			"integrity": "sha512-YtnS0VEY+e2Khzsey/6mra9EoM6h/5gxaC0e3mcHpA5yfDxafhygytNmcJWodvUgyXzSiL5MSkPO6bQGgfliHw==",
-			"dev": true,
 			"requires": {
 				"source-map": "^0.6.1"
 			},
@@ -2281,22 +2120,28 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
+			}
+		},
+		"config-chain": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+			"integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
+			"requires": {
+				"ini": "^1.3.4",
+				"proto-list": "~1.2.1"
 			}
 		},
 		"connect-history-api-fallback": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz",
-			"integrity": "sha1-5R0X+PDvDbkKZP20feMFFVbp8Wk=",
-			"dev": true
+			"integrity": "sha1-5R0X+PDvDbkKZP20feMFFVbp8Wk="
 		},
 		"console-browserify": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
 			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-			"dev": true,
 			"requires": {
 				"date-now": "^0.1.4"
 			}
@@ -2304,38 +2149,32 @@
 		"console-control-strings": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-			"dev": true
+			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
-			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
-			"dev": true
+			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
 		},
 		"content-disposition": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-			"dev": true
+			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
 		},
 		"content-type": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
-			"integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0=",
-			"dev": true
+			"integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0="
 		},
 		"content-type-parser": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
-			"integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
-			"dev": true
+			"integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
 		},
 		"conventional-changelog": {
 			"version": "1.1.22",
 			"resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.22.tgz",
 			"integrity": "sha512-CvFAZ9E/9F8abCqymsV9uDtYSN6XLoEQhFVHOcicCxnnhneLHUio0Jad8KJ+7fUUoVVL26LpIl5zjvi1SyJrww==",
-			"dev": true,
 			"requires": {
 				"conventional-changelog-angular": "^1.6.6",
 				"conventional-changelog-atom": "^0.2.7",
@@ -2354,7 +2193,6 @@
 			"version": "1.6.6",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
 			"integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
-			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
 				"q": "^1.5.1"
@@ -2364,7 +2202,6 @@
 			"version": "0.2.7",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.2.7.tgz",
 			"integrity": "sha512-h4e/hv4FtjoL5ZpAFyY1eSePFHE/BiaBNflHMY6o2R6xUEc3BubwNpuqIaXmuAG/7H+JMXoHF4HfS/wYT1VowQ==",
-			"dev": true,
 			"requires": {
 				"q": "^1.5.1"
 			}
@@ -2373,7 +2210,6 @@
 			"version": "1.3.20",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-1.3.20.tgz",
 			"integrity": "sha512-tw5NsliHuYkmKkbOfXeQb0O8v25hUm2FGeWkSDT+xhLq3O2xFFOpS3wKe+lc8FJFzJgZJ8F1F8AEDOkXtO/42g==",
-			"dev": true,
 			"requires": {
 				"add-stream": "^1.0.0",
 				"conventional-changelog": "^1.1.22",
@@ -2385,14 +2221,12 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"camelcase-keys": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
 					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0",
 						"map-obj": "^2.0.0",
@@ -2402,14 +2236,12 @@
 				"indent-string": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-					"dev": true
+					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
 				},
 				"load-json-file": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -2420,14 +2252,12 @@
 				"map-obj": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-					"dev": true
+					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
 				},
 				"meow": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
 					"integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
-					"dev": true,
 					"requires": {
 						"camelcase-keys": "^4.0.0",
 						"decamelize-keys": "^1.0.0",
@@ -2443,14 +2273,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"parse-json": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
 						"json-parse-better-errors": "^1.0.1"
@@ -2460,7 +2288,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -2469,7 +2296,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -2480,7 +2306,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -2490,7 +2315,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
 					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-					"dev": true,
 					"requires": {
 						"indent-string": "^3.0.0",
 						"strip-indent": "^2.0.0"
@@ -2499,14 +2323,12 @@
 				"strip-bom": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-					"dev": true
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 				},
 				"trim-newlines": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-					"dev": true
+					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
 				}
 			}
 		},
@@ -2514,7 +2336,6 @@
 			"version": "0.3.7",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.7.tgz",
 			"integrity": "sha512-N/hiEBFtiYRwo9hWFuk1akhmniXxVduuMN6BSgB2kFxo4sQIJQjO0JaX88RLoneXuq1CKR3Z3Lc+DTLnqg7atQ==",
-			"dev": true,
 			"requires": {
 				"q": "^1.5.1"
 			}
@@ -2523,7 +2344,6 @@
 			"version": "2.0.9",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.9.tgz",
 			"integrity": "sha512-OWbjJcZe+s+RxVQe2pe2oO1YNpWTgks6Pof99xPYxMtTRg7RnWn8E4hCIMqHtp/Q/FK7fD8Hb1i3ISwTQZWGFA==",
-			"dev": true,
 			"requires": {
 				"conventional-changelog-writer": "^3.0.8",
 				"conventional-commits-parser": "^2.1.7",
@@ -2544,7 +2364,6 @@
 			"version": "0.3.10",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.10.tgz",
 			"integrity": "sha512-EN9E3BBNXmSYyduTXPB2Vxf3XCKHycm0BrXctaVKzcOnZnj2IkcJVsK+ipMlW+Br0PeomMRCRu76SQgIE+Hn1w==",
-			"dev": true,
 			"requires": {
 				"q": "^1.5.1"
 			}
@@ -2553,7 +2372,6 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.8.tgz",
 			"integrity": "sha512-RhjwYJEympR4HtDgASEyqbVU0FRexlCcyuGbC+SaaOt3NvUwVvn4aRNu7+vzZotPZ/P7tqlCBZpN2OnT9WgncA==",
-			"dev": true,
 			"requires": {
 				"q": "^1.5.1"
 			}
@@ -2562,7 +2380,6 @@
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.3.6.tgz",
 			"integrity": "sha512-3iWVtBJZ9RnRnZveNDzOD8QRn6g6vUif0qVTWWyi5nUIAbuN1FfPVyKdAlJJfp5Im+dE8Kiy/d2SpaX/0X678Q==",
-			"dev": true,
 			"requires": {
 				"q": "^1.5.1"
 			}
@@ -2571,7 +2388,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
 			"integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
-			"dev": true,
 			"requires": {
 				"q": "^1.4.1"
 			}
@@ -2580,7 +2396,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
 			"integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
-			"dev": true,
 			"requires": {
 				"q": "^1.4.1"
 			}
@@ -2589,7 +2404,6 @@
 			"version": "0.3.7",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.7.tgz",
 			"integrity": "sha512-03S2GPwtPolFAjfrhea8QrNjfcNifoeXmYHS4gFDQETdSGW/Y3gqN0ucl8Y7cyJDOiSNmIDi3BELIID12pjSQA==",
-			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
 				"q": "^1.5.1"
@@ -2598,14 +2412,12 @@
 		"conventional-changelog-preset-loader": {
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.8.tgz",
-			"integrity": "sha512-MkksM4G4YdrMlT2MbTsV2F6LXu/hZR0Tc/yenRrDIKRwBl/SP7ER4ZDlglqJsCzLJi4UonBc52Bkm5hzrOVCcw==",
-			"dev": true
+			"integrity": "sha512-MkksM4G4YdrMlT2MbTsV2F6LXu/hZR0Tc/yenRrDIKRwBl/SP7ER4ZDlglqJsCzLJi4UonBc52Bkm5hzrOVCcw=="
 		},
 		"conventional-changelog-writer": {
 			"version": "3.0.8",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.8.tgz",
 			"integrity": "sha512-8kGEd4+UKJuNMNtOp5xSSgeH5E6ysJARDUjeq03nomjhQIpqiXj4gP61HhgdfEbk+W0RdHrz3tDf0fmYgaNMpA==",
-			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
 				"conventional-commits-filter": "^1.1.6",
@@ -2622,14 +2434,12 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"camelcase-keys": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
 					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0",
 						"map-obj": "^2.0.0",
@@ -2639,14 +2449,12 @@
 				"indent-string": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-					"dev": true
+					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
 				},
 				"load-json-file": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -2657,14 +2465,12 @@
 				"map-obj": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-					"dev": true
+					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
 				},
 				"meow": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
 					"integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
-					"dev": true,
 					"requires": {
 						"camelcase-keys": "^4.0.0",
 						"decamelize-keys": "^1.0.0",
@@ -2680,14 +2486,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"parse-json": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
 						"json-parse-better-errors": "^1.0.1"
@@ -2697,7 +2501,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -2706,7 +2509,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -2717,7 +2519,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -2727,7 +2528,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
 					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-					"dev": true,
 					"requires": {
 						"indent-string": "^3.0.0",
 						"strip-indent": "^2.0.0"
@@ -2736,20 +2536,17 @@
 				"semver": {
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-					"dev": true
+					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
 				},
 				"strip-bom": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-					"dev": true
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 				},
 				"trim-newlines": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-					"dev": true
+					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
 				}
 			}
 		},
@@ -2757,7 +2554,6 @@
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.6.tgz",
 			"integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
-			"dev": true,
 			"requires": {
 				"is-subset": "^0.1.1",
 				"modify-values": "^1.0.0"
@@ -2767,7 +2563,6 @@
 			"version": "2.1.7",
 			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
 			"integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
-			"dev": true,
 			"requires": {
 				"JSONStream": "^1.0.4",
 				"is-text-path": "^1.0.0",
@@ -2781,14 +2576,12 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"camelcase-keys": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
 					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0",
 						"map-obj": "^2.0.0",
@@ -2798,14 +2591,12 @@
 				"indent-string": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-					"dev": true
+					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
 				},
 				"load-json-file": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -2816,14 +2607,12 @@
 				"map-obj": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-					"dev": true
+					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
 				},
 				"meow": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
 					"integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
-					"dev": true,
 					"requires": {
 						"camelcase-keys": "^4.0.0",
 						"decamelize-keys": "^1.0.0",
@@ -2839,14 +2628,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"parse-json": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
 						"json-parse-better-errors": "^1.0.1"
@@ -2856,7 +2643,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -2865,7 +2651,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -2876,7 +2661,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -2886,7 +2670,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
 					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-					"dev": true,
 					"requires": {
 						"indent-string": "^3.0.0",
 						"strip-indent": "^2.0.0"
@@ -2895,14 +2678,12 @@
 				"strip-bom": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-					"dev": true
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 				},
 				"trim-newlines": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-					"dev": true
+					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
 				}
 			}
 		},
@@ -2910,7 +2691,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-1.2.1.tgz",
 			"integrity": "sha512-oJjG6DkRgtnr/t/VrPdzmf4XZv8c4xKVJrVT4zrSHd92KEL+EYxSbYoKq8lQ7U5yLMw7130wrcQTLRjM/T+d4w==",
-			"dev": true,
 			"requires": {
 				"concat-stream": "^1.4.10",
 				"conventional-commits-filter": "^1.1.1",
@@ -2924,44 +2704,37 @@
 		"convert-source-map": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-			"dev": true
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
 		},
 		"cookie": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
-			"dev": true
+			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
 		},
 		"cookie-signature": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-			"dev": true
+			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
 		},
 		"copy-descriptor": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-			"dev": true
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
 		},
 		"core-js": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-			"integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
-			"dev": true
+			"integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"cosmiconfig": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
 			"integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
-			"dev": true,
 			"requires": {
 				"is-directory": "^0.3.1",
 				"js-yaml": "^3.9.0",
@@ -2973,7 +2746,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
 						"json-parse-better-errors": "^1.0.1"
@@ -2985,7 +2757,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/cp-file/-/cp-file-5.0.0.tgz",
 			"integrity": "sha1-vHAP0wyjLSTUbH+wK5kuQ1/FqXg=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"make-dir": "^1.0.0",
@@ -2998,7 +2769,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
 			"integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.0",
 				"elliptic": "^6.0.0"
@@ -3008,7 +2778,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
 			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-			"dev": true,
 			"requires": {
 				"capture-stack-trace": "^1.0.0"
 			}
@@ -3017,7 +2786,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
 			"integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
-			"dev": true,
 			"requires": {
 				"cipher-base": "^1.0.1",
 				"inherits": "^2.0.1",
@@ -3029,7 +2797,6 @@
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
 			"integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
-			"dev": true,
 			"requires": {
 				"cipher-base": "^1.0.3",
 				"create-hash": "^1.1.0",
@@ -3043,7 +2810,6 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-			"dev": true,
 			"requires": {
 				"lru-cache": "^4.0.1",
 				"shebang-command": "^1.2.0",
@@ -3054,7 +2820,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
 			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-			"dev": true,
 			"requires": {
 				"boom": "5.x.x"
 			},
@@ -3063,7 +2828,6 @@
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
 					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-					"dev": true,
 					"requires": {
 						"hoek": "4.x.x"
 					}
@@ -3074,7 +2838,6 @@
 			"version": "3.11.1",
 			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
 			"integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
-			"dev": true,
 			"requires": {
 				"browserify-cipher": "^1.0.0",
 				"browserify-sign": "^4.0.0",
@@ -3092,7 +2855,6 @@
 			"version": "1.3.0-rc0",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.3.0-rc0.tgz",
 			"integrity": "sha1-b5MZaqrnN2ZuoQNqjLFKj8t6kjE=",
-			"dev": true,
 			"requires": {
 				"boolbase": "^1.0.0",
 				"css-what": "2.1",
@@ -3103,14 +2865,12 @@
 		"css-select-base-adapter": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.0.tgz",
-			"integrity": "sha1-AQKz0UYw34bD65+p9UVicBBs+ZA=",
-			"dev": true
+			"integrity": "sha1-AQKz0UYw34bD65+p9UVicBBs+ZA="
 		},
 		"css-tree": {
 			"version": "1.0.0-alpha.27",
 			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.27.tgz",
 			"integrity": "sha512-BAYp9FyN4jLXjfvRpTDchBllDptqlK9I7OsagXCG9Am5C+5jc8eRZHgqb9x500W2OKS14MMlpQc/nmh/aA7TEQ==",
-			"dev": true,
 			"requires": {
 				"mdn-data": "^1.0.0",
 				"source-map": "^0.5.3"
@@ -3119,20 +2879,17 @@
 		"css-url-regex": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/css-url-regex/-/css-url-regex-1.1.0.tgz",
-			"integrity": "sha1-g4NCMMyfdMRX3lnuvRVD/uuDt+w=",
-			"dev": true
+			"integrity": "sha1-g4NCMMyfdMRX3lnuvRVD/uuDt+w="
 		},
 		"css-what": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
-			"integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
-			"dev": true
+			"integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
 		},
 		"csso": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/csso/-/csso-3.5.0.tgz",
 			"integrity": "sha512-WtJjFP3ZsSdWhiZr4/k1B9uHPgYjFYnDxfbaJxk1hz5PDLIJ5BCRWkJqaztZ0DbP8d2ZIVwUPIJb2YmCwkPaMw==",
-			"dev": true,
 			"requires": {
 				"css-tree": "1.0.0-alpha.27"
 			}
@@ -3140,14 +2897,12 @@
 		"cssom": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
-			"dev": true
+			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
 		},
 		"cssstyle": {
 			"version": "0.2.37",
 			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
 			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
-			"dev": true,
 			"requires": {
 				"cssom": "0.3.x"
 			}
@@ -3156,7 +2911,6 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-			"dev": true,
 			"requires": {
 				"array-find-index": "^1.0.1"
 			}
@@ -3165,7 +2919,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
 			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-			"dev": true,
 			"requires": {
 				"es5-ext": "^0.10.9"
 			}
@@ -3174,7 +2927,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
 			"integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
-			"dev": true,
 			"requires": {
 				"number-is-nan": "^1.0.0"
 			}
@@ -3183,7 +2935,6 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			},
@@ -3191,34 +2942,29 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-					"dev": true
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 				}
 			}
 		},
 		"date-fns": {
 			"version": "1.29.0",
 			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
-			"integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
-			"dev": true
+			"integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw=="
 		},
 		"date-now": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
-			"dev": true
+			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
 		},
 		"dateformat": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
-			"dev": true
+			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
 		},
 		"debug": {
 			"version": "2.6.8",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
 			"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -3226,14 +2972,12 @@
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-			"dev": true
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
 		"decamelize-keys": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
 			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
-			"dev": true,
 			"requires": {
 				"decamelize": "^1.1.0",
 				"map-obj": "^1.0.0"
@@ -3242,38 +2986,32 @@
 		"decode-uri-component": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-			"dev": true
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
 		},
 		"dedent": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
-			"dev": true
+			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
 		},
 		"deep-equal": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-			"dev": true
+			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
 		},
 		"deep-extend": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-			"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-			"dev": true
+			"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
 		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-			"dev": true
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
 		},
 		"default-require-extensions": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
 			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
-			"dev": true,
 			"requires": {
 				"strip-bom": "^2.0.0"
 			}
@@ -3282,7 +3020,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
 			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-			"dev": true,
 			"requires": {
 				"clone": "^1.0.2"
 			}
@@ -3291,7 +3028,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-			"dev": true,
 			"requires": {
 				"foreach": "^2.0.5",
 				"object-keys": "^1.0.8"
@@ -3301,7 +3037,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-			"dev": true,
 			"requires": {
 				"is-descriptor": "^1.0.2",
 				"isobject": "^3.0.1"
@@ -3310,8 +3045,7 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
 		},
@@ -3319,7 +3053,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
 			"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
-			"dev": true,
 			"requires": {
 				"globby": "^6.1.0",
 				"is-path-cwd": "^1.0.0",
@@ -3332,34 +3065,29 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				}
 			}
 		},
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-			"dev": true
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 		},
 		"delegates": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-			"dev": true
+			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
 		},
 		"depd": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-			"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-			"dev": true
+			"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
 		},
 		"des.js": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
 			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"minimalistic-assert": "^1.0.0"
@@ -3368,14 +3096,20 @@
 		"destroy": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-			"dev": true
+			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+		},
+		"detab": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/detab/-/detab-2.0.1.tgz",
+			"integrity": "sha512-/hhdqdQc5thGrqzjyO/pz76lDZ5GSuAs6goxOaKTsvPk7HNnzAyFN5lyHgqpX4/s1i66K8qMGj+VhA9504x7DQ==",
+			"requires": {
+				"repeat-string": "^1.5.4"
+			}
 		},
 		"detect-indent": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-			"dev": true,
 			"requires": {
 				"repeating": "^2.0.0"
 			}
@@ -3383,26 +3117,22 @@
 		"detect-newline": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
-			"dev": true
+			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
 		},
 		"detect-node": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
-			"integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc=",
-			"dev": true
+			"integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc="
 		},
 		"diff": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.0.tgz",
-			"integrity": "sha512-w0XZubFWn0Adlsapj9EAWX0FqWdO4tz8kc3RiYdWLh4k/V8PTb6i0SMgXt0vRM3zyKnT8tKO7mUlieRQHIjMNg==",
-			"dev": true
+			"integrity": "sha512-w0XZubFWn0Adlsapj9EAWX0FqWdO4tz8kc3RiYdWLh4k/V8PTb6i0SMgXt0vRM3zyKnT8tKO7mUlieRQHIjMNg=="
 		},
 		"diffie-hellman": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
 			"integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.0",
 				"miller-rabin": "^4.0.0",
@@ -3413,7 +3143,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
 			"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
-			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1",
 				"path-type": "^3.0.0"
@@ -3423,7 +3152,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -3433,14 +3161,12 @@
 		"dns-equal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
-			"integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
-			"dev": true
+			"integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
 		},
 		"dns-packet": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.1.1.tgz",
 			"integrity": "sha1-I2nUUDivBF84mOb6VoYq7T9AKWw=",
-			"dev": true,
 			"requires": {
 				"ip": "^1.1.0",
 				"safe-buffer": "^5.0.1"
@@ -3450,7 +3176,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
 			"integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
-			"dev": true,
 			"requires": {
 				"buffer-indexof": "^1.0.0"
 			}
@@ -3459,7 +3184,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
 			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2"
 			}
@@ -3468,7 +3192,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
 			"integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
-			"dev": true,
 			"requires": {
 				"domelementtype": "~1.1.1",
 				"entities": "~1.1.1"
@@ -3477,34 +3200,29 @@
 				"domelementtype": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-					"dev": true
+					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
 				}
 			}
 		},
 		"dom-walk": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-			"integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
-			"dev": true
+			"integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
 		},
 		"domain-browser": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
-			"integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
-			"dev": true
+			"integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw="
 		},
 		"domelementtype": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-			"integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
-			"dev": true
+			"integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
 		},
 		"domexception": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
 			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
-			"dev": true,
 			"requires": {
 				"webidl-conversions": "^4.0.2"
 			},
@@ -3512,8 +3230,7 @@
 				"webidl-conversions": {
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-					"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-					"dev": true
+					"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
 				}
 			}
 		},
@@ -3521,7 +3238,6 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
 			"integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
-			"dev": true,
 			"requires": {
 				"domelementtype": "1"
 			}
@@ -3530,7 +3246,6 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
 			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-			"dev": true,
 			"requires": {
 				"dom-serializer": "0",
 				"domelementtype": "1"
@@ -3540,7 +3255,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
 			"integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
-			"dev": true,
 			"requires": {
 				"is-obj": "^1.0.0"
 			}
@@ -3548,48 +3262,63 @@
 		"duplexer": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-			"dev": true
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
 		},
 		"duplexer3": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-			"dev": true
+			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
 		},
 		"ecc-jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
 			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"jsbn": "~0.1.0"
 			}
 		},
+		"editorconfig": {
+			"version": "0.13.3",
+			"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.3.tgz",
+			"integrity": "sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==",
+			"requires": {
+				"bluebird": "^3.0.5",
+				"commander": "^2.9.0",
+				"lru-cache": "^3.2.0",
+				"semver": "^5.1.0",
+				"sigmund": "^1.0.1"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+					"integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
+					"requires": {
+						"pseudomap": "^1.0.1"
+					}
+				}
+			}
+		},
 		"ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-			"dev": true
+			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"electron-to-chromium": {
 			"version": "1.3.17",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.17.tgz",
-			"integrity": "sha1-QcE0V8xxZsXBXnZ65h2GqMrN7l0=",
-			"dev": true
+			"integrity": "sha1-QcE0V8xxZsXBXnZ65h2GqMrN7l0="
 		},
 		"elegant-spinner": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
-			"integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
-			"dev": true
+			"integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4="
 		},
 		"elliptic": {
 			"version": "6.4.0",
 			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
 			"integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.4.0",
 				"brorand": "^1.0.1",
@@ -3600,23 +3329,33 @@
 				"minimalistic-crypto-utils": "^1.0.0"
 			}
 		},
+		"emoji-regex": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
+			"integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4="
+		},
 		"emojis-list": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-			"dev": true
+			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
 		},
 		"encodeurl": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-			"integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
-			"dev": true
+			"integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
+		},
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"requires": {
+				"iconv-lite": "~0.4.13"
+			}
 		},
 		"enhanced-resolve": {
 			"version": "3.4.1",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
 			"integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"memory-fs": "^0.4.0",
@@ -3627,14 +3366,12 @@
 		"entities": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-			"integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
-			"dev": true
+			"integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
 		},
 		"errno": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
 			"integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-			"dev": true,
 			"requires": {
 				"prr": "~0.0.0"
 			}
@@ -3643,7 +3380,6 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-			"dev": true,
 			"requires": {
 				"is-arrayish": "^0.2.1"
 			}
@@ -3652,7 +3388,6 @@
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
 			"integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
-			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.1.1",
 				"function-bind": "^1.1.1",
@@ -3665,7 +3400,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-			"dev": true,
 			"requires": {
 				"is-callable": "^1.1.1",
 				"is-date-object": "^1.0.1",
@@ -3676,7 +3410,6 @@
 			"version": "0.10.26",
 			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.26.tgz",
 			"integrity": "sha1-UbISilMbcMT2dkCTpzy+u4IYY3I=",
-			"dev": true,
 			"requires": {
 				"es6-iterator": "2",
 				"es6-symbol": "~3.1"
@@ -3686,7 +3419,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
 			"integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-			"dev": true,
 			"requires": {
 				"d": "1",
 				"es5-ext": "^0.10.14",
@@ -3697,7 +3429,6 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
 			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-			"dev": true,
 			"requires": {
 				"d": "1",
 				"es5-ext": "~0.10.14",
@@ -3711,7 +3442,6 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
 			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-			"dev": true,
 			"requires": {
 				"d": "1",
 				"es5-ext": "~0.10.14",
@@ -3724,7 +3454,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
 			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-			"dev": true,
 			"requires": {
 				"d": "1",
 				"es5-ext": "~0.10.14"
@@ -3734,7 +3463,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
 			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-			"dev": true,
 			"requires": {
 				"d": "1",
 				"es5-ext": "^0.10.14",
@@ -3745,20 +3473,17 @@
 		"escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-			"dev": true
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"escodegen": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
 			"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
-			"dev": true,
 			"requires": {
 				"esprima": "^3.1.3",
 				"estraverse": "^4.2.0",
@@ -3770,14 +3495,12 @@
 				"esprima": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-					"dev": true
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true,
 					"optional": true
 				}
 			}
@@ -3786,7 +3509,6 @@
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
 			"integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-			"dev": true,
 			"requires": {
 				"es6-map": "^0.1.3",
 				"es6-weak-map": "^2.0.1",
@@ -3798,7 +3520,6 @@
 			"version": "4.19.1",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
 			"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
-			"dev": true,
 			"requires": {
 				"ajv": "^5.3.0",
 				"babel-code-frame": "^6.22.0",
@@ -3844,7 +3565,6 @@
 					"version": "5.5.2",
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-					"dev": true,
 					"requires": {
 						"co": "^4.6.0",
 						"fast-deep-equal": "^1.0.0",
@@ -3855,14 +3575,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -3871,7 +3589,6 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -3882,7 +3599,6 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -3890,20 +3606,17 @@
 				"globals": {
 					"version": "11.4.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
-					"integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA==",
-					"dev": true
+					"integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA=="
 				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -3912,7 +3625,6 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -3923,7 +3635,6 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",
 			"integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
-			"dev": true,
 			"requires": {
 				"ignore": "^3.3.6",
 				"minimatch": "^3.0.4",
@@ -3935,7 +3646,6 @@
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
 			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-			"dev": true,
 			"requires": {
 				"esrecurse": "^4.1.0",
 				"estraverse": "^4.1.1"
@@ -3944,14 +3654,12 @@
 		"eslint-visitor-keys": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
-			"dev": true
+			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
 		},
 		"espree": {
 			"version": "3.5.4",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
 			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
-			"dev": true,
 			"requires": {
 				"acorn": "^5.5.0",
 				"acorn-jsx": "^3.0.0"
@@ -3960,22 +3668,19 @@
 				"acorn": {
 					"version": "5.5.3",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-					"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
-					"dev": true
+					"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
 				}
 			}
 		},
 		"esprima": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-			"dev": true
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
 		},
 		"esquery": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
 			"integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-			"dev": true,
 			"requires": {
 				"estraverse": "^4.0.0"
 			}
@@ -3984,7 +3689,6 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
 			"integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
-			"dev": true,
 			"requires": {
 				"estraverse": "^4.1.0",
 				"object-assign": "^4.0.1"
@@ -3993,32 +3697,27 @@
 		"estraverse": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-			"dev": true
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
 		},
 		"estree-walker": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz",
-			"integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao=",
-			"dev": true
+			"integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao="
 		},
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-			"dev": true
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
 		},
 		"etag": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
-			"integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE=",
-			"dev": true
+			"integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE="
 		},
 		"event-emitter": {
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
 			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-			"dev": true,
 			"requires": {
 				"d": "1",
 				"es5-ext": "~0.10.14"
@@ -4027,20 +3726,17 @@
 		"eventemitter3": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
-			"integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=",
-			"dev": true
+			"integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
 		},
 		"events": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-			"dev": true
+			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
 		},
 		"eventsource": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
 			"integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
-			"dev": true,
 			"requires": {
 				"original": ">=0.0.5"
 			}
@@ -4049,7 +3745,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
 			"integrity": "sha1-SXtmrZ/vZc18CKYYCCS6FHa2blM=",
-			"dev": true,
 			"requires": {
 				"create-hash": "^1.1.1"
 			}
@@ -4058,7 +3753,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
 			"integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
-			"dev": true,
 			"requires": {
 				"merge": "^1.1.3"
 			}
@@ -4067,7 +3761,6 @@
 			"version": "0.8.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
 			"integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
-			"dev": true,
 			"requires": {
 				"cross-spawn": "^5.0.1",
 				"get-stream": "^3.0.0",
@@ -4081,20 +3774,17 @@
 		"exit": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-			"dev": true
+			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
 		},
 		"exit-hook": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
-			"dev": true
+			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
 		},
 		"expand-brackets": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-			"dev": true,
 			"requires": {
 				"is-posix-bracket": "^0.1.0"
 			}
@@ -4103,7 +3793,6 @@
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-			"dev": true,
 			"requires": {
 				"fill-range": "^2.1.0"
 			}
@@ -4112,7 +3801,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/expect/-/expect-22.4.3.tgz",
 			"integrity": "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.0",
 				"jest-diff": "^22.4.3",
@@ -4125,14 +3813,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -4141,7 +3827,6 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -4151,14 +3836,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"jest-diff": {
 					"version": "22.4.3",
 					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
 					"integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"diff": "^3.2.0",
@@ -4170,7 +3853,6 @@
 					"version": "22.4.3",
 					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
 					"integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"jest-get-type": "^22.4.3",
@@ -4181,7 +3863,6 @@
 					"version": "22.4.3",
 					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
 					"integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0-beta.35",
 						"chalk": "^2.0.1",
@@ -4193,14 +3874,12 @@
 				"jest-regex-util": {
 					"version": "22.4.3",
 					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.4.3.tgz",
-					"integrity": "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg==",
-					"dev": true
+					"integrity": "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg=="
 				},
 				"pretty-format": {
 					"version": "22.4.3",
 					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
 					"integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0",
 						"ansi-styles": "^3.2.0"
@@ -4210,7 +3889,6 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -4221,7 +3899,6 @@
 			"version": "4.15.3",
 			"resolved": "https://registry.npmjs.org/express/-/express-4.15.3.tgz",
 			"integrity": "sha1-urZdDwOqgMNYQIly/HAPkWlEtmI=",
-			"dev": true,
 			"requires": {
 				"accepts": "~1.3.3",
 				"array-flatten": "1.1.1",
@@ -4256,14 +3933,12 @@
 				"array-flatten": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-					"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
-					"dev": true
+					"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
 				},
 				"debug": {
 					"version": "2.6.7",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
 					"integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -4273,14 +3948,12 @@
 		"extend": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-			"dev": true
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-			"dev": true,
 			"requires": {
 				"assign-symbols": "^1.0.0",
 				"is-extendable": "^1.0.1"
@@ -4290,7 +3963,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"dev": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
@@ -4301,7 +3973,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
 			"integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
-			"dev": true,
 			"requires": {
 				"chardet": "^0.4.0",
 				"iconv-lite": "^0.4.17",
@@ -4312,7 +3983,6 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-			"dev": true,
 			"requires": {
 				"is-extglob": "^1.0.0"
 			}
@@ -4320,20 +3990,17 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-			"dev": true
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 		},
 		"fast-deep-equal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-			"integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
-			"dev": true
+			"integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
 		},
 		"fast-glob": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.0.tgz",
 			"integrity": "sha512-4F75PTznkNtSKs2pbhtBwRkw8sRwa7LfXx5XaQJOe4IQ6yTjceLDTwM5gj1s80R2t/5WeDC1gVfm3jLE+l39Tw==",
-			"dev": true,
 			"requires": {
 				"@mrmlnc/readdir-enhanced": "^2.2.1",
 				"glob-parent": "^3.1.0",
@@ -4345,20 +4012,17 @@
 				"arr-diff": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
 				},
 				"array-unique": {
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 				},
 				"braces": {
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"dev": true,
 					"requires": {
 						"arr-flatten": "^1.1.0",
 						"array-unique": "^0.3.2",
@@ -4376,7 +4040,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -4387,7 +4050,6 @@
 					"version": "2.1.4",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"dev": true,
 					"requires": {
 						"debug": "^2.3.3",
 						"define-property": "^0.2.5",
@@ -4402,7 +4064,6 @@
 							"version": "0.2.5",
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
@@ -4411,7 +4072,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -4420,7 +4080,6 @@
 							"version": "0.1.6",
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^0.1.6",
 								"is-data-descriptor": "^0.1.4",
@@ -4430,8 +4089,7 @@
 						"kind-of": {
 							"version": "5.1.0",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-							"dev": true
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 						}
 					}
 				},
@@ -4439,7 +4097,6 @@
 					"version": "2.0.4",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"dev": true,
 					"requires": {
 						"array-unique": "^0.3.2",
 						"define-property": "^1.0.0",
@@ -4455,7 +4112,6 @@
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
 							"requires": {
 								"is-descriptor": "^1.0.0"
 							}
@@ -4464,7 +4120,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -4475,7 +4130,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"dev": true,
 					"requires": {
 						"extend-shallow": "^2.0.1",
 						"is-number": "^3.0.0",
@@ -4487,7 +4141,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -4498,7 +4151,6 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
 					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-					"dev": true,
 					"requires": {
 						"is-glob": "^3.1.0",
 						"path-dirname": "^1.0.0"
@@ -4508,7 +4160,6 @@
 							"version": "3.1.0",
 							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-							"dev": true,
 							"requires": {
 								"is-extglob": "^2.1.0"
 							}
@@ -4519,7 +4170,6 @@
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
@@ -4528,7 +4178,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -4539,7 +4188,6 @@
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
@@ -4548,7 +4196,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -4558,14 +4205,12 @@
 				"is-extglob": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-					"dev": true
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 				},
 				"is-glob": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^2.1.1"
 					}
@@ -4574,7 +4219,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
@@ -4583,7 +4227,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -4593,20 +4236,17 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				},
 				"micromatch": {
 					"version": "3.1.10",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"dev": true,
 					"requires": {
 						"arr-diff": "^4.0.0",
 						"array-unique": "^0.3.2",
@@ -4628,20 +4268,17 @@
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-			"dev": true
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-			"dev": true
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
 		},
 		"faye-websocket": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
 			"integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
-			"dev": true,
 			"requires": {
 				"websocket-driver": ">=0.5.1"
 			}
@@ -4650,16 +4287,35 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
 			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
-			"dev": true,
 			"requires": {
 				"bser": "^2.0.0"
+			}
+		},
+		"fbjs": {
+			"version": "0.8.17",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+			"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+			"requires": {
+				"core-js": "^1.0.0",
+				"isomorphic-fetch": "^2.1.1",
+				"loose-envify": "^1.0.0",
+				"object-assign": "^4.1.0",
+				"promise": "^7.1.1",
+				"setimmediate": "^1.0.5",
+				"ua-parser-js": "^0.7.18"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+				}
 			}
 		},
 		"figures": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
 			}
@@ -4668,7 +4324,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-			"dev": true,
 			"requires": {
 				"flat-cache": "^1.2.1",
 				"object-assign": "^4.0.1"
@@ -4677,14 +4332,12 @@
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-			"dev": true
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
 		},
 		"fileset": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
 			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
-			"dev": true,
 			"requires": {
 				"glob": "^7.0.3",
 				"minimatch": "^3.0.3"
@@ -4694,7 +4347,6 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-			"dev": true,
 			"requires": {
 				"is-number": "^2.1.0",
 				"isobject": "^2.0.0",
@@ -4707,7 +4359,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.4.tgz",
 			"integrity": "sha512-16l/r8RgzlXKmFOhZpHBztvye+lAhC5SU7hXavnerC9UfZqZxxXl3BzL8MhffPT3kF61lj9Oav2LKEzh0ei7tg==",
-			"dev": true,
 			"requires": {
 				"debug": "2.6.8",
 				"encodeurl": "~1.0.1",
@@ -4722,7 +4373,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
 			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
-			"dev": true,
 			"requires": {
 				"commondir": "^1.0.1",
 				"make-dir": "^1.0.0",
@@ -4732,14 +4382,12 @@
 		"find-parent-dir": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
-			"integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
-			"dev": true
+			"integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ="
 		},
 		"find-up": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-			"dev": true,
 			"requires": {
 				"locate-path": "^2.0.0"
 			}
@@ -4748,7 +4396,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
 			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
-			"dev": true,
 			"requires": {
 				"circular-json": "^0.3.1",
 				"del": "^2.0.2",
@@ -4760,7 +4407,6 @@
 					"version": "2.2.2",
 					"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
 					"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-					"dev": true,
 					"requires": {
 						"globby": "^5.0.0",
 						"is-path-cwd": "^1.0.0",
@@ -4775,7 +4421,6 @@
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
 					"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-					"dev": true,
 					"requires": {
 						"array-union": "^1.0.1",
 						"arrify": "^1.0.0",
@@ -4788,22 +4433,19 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				}
 			}
 		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-			"dev": true
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
 		},
 		"for-own": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-			"dev": true,
 			"requires": {
 				"for-in": "^1.0.1"
 			}
@@ -4811,20 +4453,17 @@
 		"foreach": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-			"dev": true
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
 		},
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-			"dev": true
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 		},
 		"form-data": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-			"dev": true,
 			"requires": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "1.0.6",
@@ -4835,7 +4474,6 @@
 					"version": "1.0.6",
 					"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
 					"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-					"dev": true,
 					"requires": {
 						"delayed-stream": "~1.0.0"
 					}
@@ -4845,14 +4483,12 @@
 		"forwarded": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
-			"integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M=",
-			"dev": true
+			"integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M="
 		},
 		"fragment-cache": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-			"dev": true,
 			"requires": {
 				"map-cache": "^0.2.2"
 			}
@@ -4860,14 +4496,31 @@
 		"fresh": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
-			"integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
-			"dev": true
+			"integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44="
+		},
+		"front-matter": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/front-matter/-/front-matter-2.3.0.tgz",
+			"integrity": "sha1-cgOviWzjV+4E4qpFFp6pHtf2dQQ=",
+			"requires": {
+				"js-yaml": "^3.10.0"
+			},
+			"dependencies": {
+				"js-yaml": {
+					"version": "3.12.0",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+					"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				}
+			}
 		},
 		"fs-extra": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
 			"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"jsonfile": "^4.0.0",
@@ -4877,14 +4530,12 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
 			"integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"nan": "^2.3.0",
@@ -4895,14 +4546,12 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
 					"integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
-					"dev": true,
 					"optional": true
 				},
 				"ajv": {
 					"version": "4.11.8",
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
 					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"co": "^4.6.0",
@@ -4912,21 +4561,18 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 				},
 				"aproba": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
 					"integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
-					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
 					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
 					"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"delegates": "^1.0.0",
@@ -4937,48 +4583,41 @@
 					"version": "0.2.3",
 					"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
 					"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-					"dev": true,
 					"optional": true
 				},
 				"assert-plus": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
 					"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-					"dev": true,
 					"optional": true
 				},
 				"asynckit": {
 					"version": "0.4.0",
 					"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 					"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-					"dev": true,
 					"optional": true
 				},
 				"aws-sign2": {
 					"version": "0.6.0",
 					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
 					"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-					"dev": true,
 					"optional": true
 				},
 				"aws4": {
 					"version": "1.6.0",
 					"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
 					"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-					"dev": true,
 					"optional": true
 				},
 				"balanced-match": {
 					"version": "0.4.2",
 					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-					"dev": true
+					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
 				},
 				"bcrypt-pbkdf": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
 					"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"tweetnacl": "^0.14.3"
@@ -4988,7 +4627,6 @@
 					"version": "0.0.9",
 					"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
 					"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-					"dev": true,
 					"requires": {
 						"inherits": "~2.0.0"
 					}
@@ -4997,7 +4635,6 @@
 					"version": "2.10.1",
 					"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
 					"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-					"dev": true,
 					"requires": {
 						"hoek": "2.x.x"
 					}
@@ -5006,7 +4643,6 @@
 					"version": "1.1.7",
 					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
 					"integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
-					"dev": true,
 					"requires": {
 						"balanced-match": "^0.4.1",
 						"concat-map": "0.0.1"
@@ -5015,34 +4651,29 @@
 				"buffer-shims": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-					"integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-					"dev": true
+					"integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
 				},
 				"caseless": {
 					"version": "0.12.0",
 					"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 					"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-					"dev": true,
 					"optional": true
 				},
 				"co": {
 					"version": "4.6.0",
 					"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
 					"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-					"dev": true
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 				},
 				"combined-stream": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
 					"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-					"dev": true,
 					"requires": {
 						"delayed-stream": "~1.0.0"
 					}
@@ -5050,26 +4681,22 @@
 				"concat-map": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-					"dev": true
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-					"dev": true
+					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 				},
 				"core-util-is": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-					"dev": true
+					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 				},
 				"cryptiles": {
 					"version": "2.0.5",
 					"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
 					"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"boom": "2.x.x"
@@ -5079,7 +4706,6 @@
 					"version": "1.14.1",
 					"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 					"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "^1.0.0"
@@ -5089,7 +4715,6 @@
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-							"dev": true,
 							"optional": true
 						}
 					}
@@ -5098,7 +4723,6 @@
 					"version": "2.6.8",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
 					"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -5108,27 +4732,23 @@
 					"version": "0.4.2",
 					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
 					"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-					"dev": true,
 					"optional": true
 				},
 				"delayed-stream": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-					"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-					"dev": true
+					"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 				},
 				"delegates": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
 					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-					"dev": true,
 					"optional": true
 				},
 				"ecc-jsbn": {
 					"version": "0.1.1",
 					"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
 					"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsbn": "~0.1.0"
@@ -5138,27 +4758,23 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
 					"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-					"dev": true,
 					"optional": true
 				},
 				"extsprintf": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-					"integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-					"dev": true
+					"integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
 				},
 				"forever-agent": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
 					"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-					"dev": true,
 					"optional": true
 				},
 				"form-data": {
 					"version": "2.1.4",
 					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
 					"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"asynckit": "^0.4.0",
@@ -5169,14 +4785,12 @@
 				"fs.realpath": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-					"dev": true
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 				},
 				"fstream": {
 					"version": "1.0.11",
 					"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
 					"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"inherits": "~2.0.0",
@@ -5188,7 +4802,6 @@
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
 					"integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"fstream": "^1.0.0",
@@ -5200,7 +4813,6 @@
 					"version": "2.7.4",
 					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"aproba": "^1.0.3",
@@ -5217,7 +4829,6 @@
 					"version": "0.1.7",
 					"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 					"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "^1.0.0"
@@ -5227,7 +4838,6 @@
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-							"dev": true,
 							"optional": true
 						}
 					}
@@ -5236,7 +4846,6 @@
 					"version": "7.1.2",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
@@ -5249,21 +4858,18 @@
 				"graceful-fs": {
 					"version": "4.1.11",
 					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-					"dev": true
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
 				},
 				"har-schema": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
 					"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-					"dev": true,
 					"optional": true
 				},
 				"har-validator": {
 					"version": "4.2.1",
 					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
 					"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"ajv": "^4.9.1",
@@ -5274,14 +4880,12 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
 					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-					"dev": true,
 					"optional": true
 				},
 				"hawk": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
 					"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"boom": "2.x.x",
@@ -5293,14 +4897,12 @@
 				"hoek": {
 					"version": "2.16.3",
 					"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-					"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-					"dev": true
+					"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
 				},
 				"http-signature": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
 					"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "^0.2.0",
@@ -5312,7 +4914,6 @@
 					"version": "1.0.6",
 					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-					"dev": true,
 					"requires": {
 						"once": "^1.3.0",
 						"wrappy": "1"
@@ -5321,21 +4922,18 @@
 				"inherits": {
 					"version": "2.0.3",
 					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-					"dev": true
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 				},
 				"ini": {
 					"version": "1.3.4",
 					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
 					"integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -5344,27 +4942,23 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
 					"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-					"dev": true,
 					"optional": true
 				},
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-					"dev": true
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
 				"isstream": {
 					"version": "0.1.2",
 					"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
 					"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-					"dev": true,
 					"optional": true
 				},
 				"jodid25519": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
 					"integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsbn": "~0.1.0"
@@ -5374,21 +4968,18 @@
 					"version": "0.1.1",
 					"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 					"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-					"dev": true,
 					"optional": true
 				},
 				"json-schema": {
 					"version": "0.2.3",
 					"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
 					"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-					"dev": true,
 					"optional": true
 				},
 				"json-stable-stringify": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
 					"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsonify": "~0.0.0"
@@ -5398,21 +4989,18 @@
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 					"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-					"dev": true,
 					"optional": true
 				},
 				"jsonify": {
 					"version": "0.0.0",
 					"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
 					"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-					"dev": true,
 					"optional": true
 				},
 				"jsprim": {
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
 					"integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0",
@@ -5425,7 +5013,6 @@
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-							"dev": true,
 							"optional": true
 						}
 					}
@@ -5433,14 +5020,12 @@
 				"mime-db": {
 					"version": "1.27.0",
 					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-					"integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
-					"dev": true
+					"integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
 				},
 				"mime-types": {
 					"version": "2.1.15",
 					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
 					"integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-					"dev": true,
 					"requires": {
 						"mime-db": "~1.27.0"
 					}
@@ -5449,7 +5034,6 @@
 					"version": "3.0.4",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-					"dev": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -5457,14 +5041,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-					"dev": true
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 				},
 				"mkdirp": {
 					"version": "0.5.1",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -5473,14 +5055,12 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true,
 					"optional": true
 				},
 				"node-pre-gyp": {
 					"version": "0.6.36",
 					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
 					"integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"mkdirp": "^0.5.1",
@@ -5498,7 +5078,6 @@
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"abbrev": "1",
@@ -5509,7 +5088,6 @@
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
 					"integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"are-we-there-yet": "~1.1.2",
@@ -5521,28 +5099,24 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-					"dev": true
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 				},
 				"oauth-sign": {
 					"version": "0.8.2",
 					"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
 					"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-					"dev": true,
 					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-					"dev": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -5551,21 +5125,18 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
 					"integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"os-homedir": "^1.0.0",
@@ -5575,41 +5146,35 @@
 				"path-is-absolute": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-					"dev": true
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 				},
 				"performance-now": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
 					"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "1.0.7",
 					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-					"dev": true
+					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
 				},
 				"punycode": {
 					"version": "1.4.1",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
 					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"dev": true,
 					"optional": true
 				},
 				"qs": {
 					"version": "6.4.0",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
 					"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
 					"integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"deep-extend": "~0.4.0",
@@ -5622,7 +5187,6 @@
 							"version": "1.2.0",
 							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-							"dev": true,
 							"optional": true
 						}
 					}
@@ -5631,7 +5195,6 @@
 					"version": "2.2.9",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
 					"integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
-					"dev": true,
 					"requires": {
 						"buffer-shims": "~1.0.0",
 						"core-util-is": "~1.0.0",
@@ -5646,7 +5209,6 @@
 					"version": "2.81.0",
 					"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
 					"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"aws-sign2": "~0.6.0",
@@ -5677,7 +5239,6 @@
 					"version": "2.6.1",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
 					"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-					"dev": true,
 					"requires": {
 						"glob": "^7.0.5"
 					}
@@ -5685,35 +5246,30 @@
 				"safe-buffer": {
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-					"integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-					"dev": true
+					"integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
 				},
 				"semver": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
 					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-					"dev": true,
 					"optional": true
 				},
 				"sntp": {
 					"version": "1.0.9",
 					"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
 					"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"hoek": "2.x.x"
@@ -5723,7 +5279,6 @@
 					"version": "1.13.0",
 					"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
 					"integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"asn1": "~0.2.3",
@@ -5741,7 +5296,6 @@
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-							"dev": true,
 							"optional": true
 						}
 					}
@@ -5750,7 +5304,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -5761,7 +5314,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
 					"integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-					"dev": true,
 					"requires": {
 						"safe-buffer": "^5.0.1"
 					}
@@ -5770,14 +5322,12 @@
 					"version": "0.0.5",
 					"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
 					"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-					"dev": true,
 					"optional": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -5786,14 +5336,12 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
 					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
 					"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-					"dev": true,
 					"requires": {
 						"block-stream": "*",
 						"fstream": "^1.0.2",
@@ -5804,7 +5352,6 @@
 					"version": "3.4.0",
 					"resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
 					"integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"debug": "^2.2.0",
@@ -5821,7 +5368,6 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
 					"integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"punycode": "^1.4.1"
@@ -5831,7 +5377,6 @@
 					"version": "0.6.0",
 					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 					"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.0.1"
@@ -5841,34 +5386,29 @@
 					"version": "0.14.5",
 					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 					"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-					"dev": true,
 					"optional": true
 				},
 				"uid-number": {
 					"version": "0.0.6",
 					"resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
 					"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
-					"dev": true,
 					"optional": true
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-					"dev": true
+					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 				},
 				"uuid": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
 					"integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
-					"dev": true,
 					"optional": true
 				},
 				"verror": {
 					"version": "1.3.6",
 					"resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
 					"integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"extsprintf": "1.0.2"
@@ -5878,7 +5418,6 @@
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
 					"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"string-width": "^1.0.2"
@@ -5887,28 +5426,24 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-					"dev": true
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 				}
 			}
 		},
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
 		"functional-red-black-tree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-			"dev": true
+			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
 		},
 		"gauge": {
 			"version": "2.7.4",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"dev": true,
 			"requires": {
 				"aproba": "^1.0.3",
 				"console-control-strings": "^1.0.0",
@@ -5924,7 +5459,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -5933,7 +5467,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -5945,20 +5478,17 @@
 		"get-caller-file": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-			"dev": true
+			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
 		},
 		"get-own-enumerable-property-symbols": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
-			"integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
-			"dev": true
+			"integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug=="
 		},
 		"get-pkg-repo": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
 			"integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
-			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.1.4",
 				"meow": "^3.3.0",
@@ -5970,32 +5500,27 @@
 		"get-port": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
-			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
-			"dev": true
+			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
 		},
 		"get-stdin": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-			"dev": true
+			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
 		},
 		"get-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-			"dev": true
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
 		},
 		"get-value": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-			"dev": true
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
 		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			},
@@ -6003,8 +5528,7 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-					"dev": true
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 				}
 			}
 		},
@@ -6012,7 +5536,6 @@
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
 			"integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
-			"dev": true,
 			"requires": {
 				"dargs": "^4.0.1",
 				"lodash.template": "^4.0.2",
@@ -6024,14 +5547,12 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"camelcase-keys": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
 					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0",
 						"map-obj": "^2.0.0",
@@ -6041,14 +5562,12 @@
 				"indent-string": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-					"dev": true
+					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
 				},
 				"load-json-file": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -6059,14 +5578,12 @@
 				"map-obj": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-					"dev": true
+					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
 				},
 				"meow": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
 					"integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
-					"dev": true,
 					"requires": {
 						"camelcase-keys": "^4.0.0",
 						"decamelize-keys": "^1.0.0",
@@ -6082,14 +5599,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"parse-json": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
 						"json-parse-better-errors": "^1.0.1"
@@ -6099,7 +5614,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -6108,7 +5622,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -6119,7 +5632,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -6129,7 +5641,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
 					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-					"dev": true,
 					"requires": {
 						"indent-string": "^3.0.0",
 						"strip-indent": "^2.0.0"
@@ -6138,14 +5649,12 @@
 				"strip-bom": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-					"dev": true
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 				},
 				"trim-newlines": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-					"dev": true
+					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
 				}
 			}
 		},
@@ -6153,7 +5662,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
 			"integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
-			"dev": true,
 			"requires": {
 				"gitconfiglocal": "^1.0.0",
 				"pify": "^2.3.0"
@@ -6162,8 +5670,7 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				}
 			}
 		},
@@ -6171,7 +5678,6 @@
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.6.tgz",
 			"integrity": "sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==",
-			"dev": true,
 			"requires": {
 				"meow": "^4.0.0",
 				"semver": "^5.5.0"
@@ -6180,14 +5686,12 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"camelcase-keys": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
 					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0",
 						"map-obj": "^2.0.0",
@@ -6197,14 +5701,12 @@
 				"indent-string": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-					"dev": true
+					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
 				},
 				"load-json-file": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -6215,14 +5717,12 @@
 				"map-obj": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-					"dev": true
+					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
 				},
 				"meow": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
 					"integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
-					"dev": true,
 					"requires": {
 						"camelcase-keys": "^4.0.0",
 						"decamelize-keys": "^1.0.0",
@@ -6238,14 +5738,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"parse-json": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
 						"json-parse-better-errors": "^1.0.1"
@@ -6255,7 +5753,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -6264,7 +5761,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -6275,7 +5771,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -6285,7 +5780,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
 					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-					"dev": true,
 					"requires": {
 						"indent-string": "^3.0.0",
 						"strip-indent": "^2.0.0"
@@ -6294,20 +5788,17 @@
 				"semver": {
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-					"dev": true
+					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
 				},
 				"strip-bom": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-					"dev": true
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 				},
 				"trim-newlines": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-					"dev": true
+					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
 				}
 			}
 		},
@@ -6315,16 +5806,22 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
 			"integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
-			"dev": true,
 			"requires": {
 				"ini": "^1.3.2"
+			}
+		},
+		"github-slugger": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.2.0.tgz",
+			"integrity": "sha512-wIaa75k1vZhyPm9yWrD08A5Xnx/V+RmzGrpjQuLemGKSb77Qukiaei58Bogrl/LZSADDfPzKJX8jhLs4CRTl7Q==",
+			"requires": {
+				"emoji-regex": ">=6.0.0 <=6.1.1"
 			}
 		},
 		"glob": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -6338,7 +5835,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-			"dev": true,
 			"requires": {
 				"glob-parent": "^2.0.0",
 				"is-glob": "^2.0.0"
@@ -6348,7 +5844,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-			"dev": true,
 			"requires": {
 				"is-glob": "^2.0.0"
 			}
@@ -6356,14 +5851,12 @@
 		"glob-to-regexp": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
-			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
-			"dev": true
+			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
 		},
 		"global": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
 			"integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
-			"dev": true,
 			"requires": {
 				"min-document": "^2.19.0",
 				"process": "~0.5.1"
@@ -6372,22 +5865,19 @@
 				"process": {
 					"version": "0.5.2",
 					"resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-					"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
-					"dev": true
+					"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
 				}
 			}
 		},
 		"globals": {
 			"version": "9.18.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-			"dev": true
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
 		},
 		"globby": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
 			"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-			"dev": true,
 			"requires": {
 				"array-union": "^1.0.1",
 				"glob": "^7.0.3",
@@ -6399,8 +5889,7 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				}
 			}
 		},
@@ -6408,7 +5897,6 @@
 			"version": "6.7.1",
 			"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
 			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-			"dev": true,
 			"requires": {
 				"create-error-class": "^3.0.0",
 				"duplexer3": "^0.1.4",
@@ -6426,26 +5914,22 @@
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-			"dev": true
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
 		},
 		"growly": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-			"dev": true
+			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
 		},
 		"handle-thing": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
-			"integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
-			"dev": true
+			"integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
 		},
 		"handlebars": {
 			"version": "4.0.10",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
 			"integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
-			"dev": true,
 			"requires": {
 				"async": "^1.4.0",
 				"optimist": "^0.6.1",
@@ -6456,14 +5940,12 @@
 				"async": {
 					"version": "1.5.2",
 					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-					"dev": true
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 				},
 				"source-map": {
 					"version": "0.4.4",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-					"dev": true,
 					"requires": {
 						"amdefine": ">=0.0.4"
 					}
@@ -6473,14 +5955,12 @@
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-			"dev": true
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
 		},
 		"har-validator": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-			"dev": true,
 			"requires": {
 				"ajv": "^5.1.0",
 				"har-schema": "^2.0.0"
@@ -6490,7 +5970,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-			"dev": true,
 			"requires": {
 				"function-bind": "^1.0.2"
 			}
@@ -6499,7 +5978,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			}
@@ -6507,20 +5985,17 @@
 		"has-flag": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-			"dev": true
+			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
 		},
 		"has-unicode": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-			"dev": true
+			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
 		},
 		"has-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-			"dev": true,
 			"requires": {
 				"get-value": "^2.0.6",
 				"has-values": "^1.0.0",
@@ -6530,8 +6005,7 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
 		},
@@ -6539,7 +6013,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-			"dev": true,
 			"requires": {
 				"is-number": "^3.0.0",
 				"kind-of": "^4.0.0"
@@ -6549,7 +6022,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
@@ -6558,7 +6030,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -6569,7 +6040,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -6580,7 +6050,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
 			"integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1"
 			}
@@ -6589,17 +6058,107 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
 			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.0"
+			}
+		},
+		"hast-to-hyperscript": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-3.1.0.tgz",
+			"integrity": "sha512-/At2y6sQLTAcL6y+3hRQFcaBoRlKrmHSpvvdOZqRz6uI2YyjrU8rJ7e1LbmLtWUmzaIqKEdNSku+AJC0pt4+aw==",
+			"requires": {
+				"comma-separated-tokens": "^1.0.0",
+				"is-nan": "^1.2.1",
+				"kebab-case": "^1.0.0",
+				"property-information": "^3.0.0",
+				"space-separated-tokens": "^1.0.0",
+				"trim": "0.0.1",
+				"unist-util-is": "^2.0.0"
+			}
+		},
+		"hast-util-from-parse5": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-2.1.0.tgz",
+			"integrity": "sha1-9hI9g9NoljCwl+E+Qw0W2dG9iIQ=",
+			"requires": {
+				"camelcase": "^3.0.0",
+				"hastscript": "^3.0.0",
+				"property-information": "^3.1.0",
+				"vfile-location": "^2.0.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+				}
+			}
+		},
+		"hast-util-parse-selector": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.1.0.tgz",
+			"integrity": "sha1-tVwPS7e7IEDIicMl74erKcOBArQ="
+		},
+		"hast-util-raw": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-2.0.2.tgz",
+			"integrity": "sha512-ujytXSAZC85bvh38f8ALzfE2IZDdCwB9XeHUs9l20C1p4/1YeAoZqq9z9U17vWQ9hMmqbVaROuSK8feL3wTCJg==",
+			"requires": {
+				"hast-util-from-parse5": "^2.0.0",
+				"hast-util-to-parse5": "^2.0.0",
+				"html-void-elements": "^1.0.1",
+				"parse5": "^3.0.3",
+				"unist-util-position": "^3.0.0",
+				"web-namespaces": "^1.0.0",
+				"zwitch": "^1.0.0"
+			},
+			"dependencies": {
+				"parse5": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+					"integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+					"requires": {
+						"@types/node": "*"
+					}
+				}
+			}
+		},
+		"hast-util-to-parse5": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-2.2.0.tgz",
+			"integrity": "sha512-Eg1mrf0VTT/PipFN5z1+mVi+4GNhinKk/i/HKeX1h17IYiMdm3G8vgA0FU04XCuD1cWV58f5zziFKcBkr+WuKw==",
+			"requires": {
+				"hast-to-hyperscript": "^3.0.0",
+				"mapz": "^1.0.0",
+				"web-namespaces": "^1.0.0",
+				"xtend": "^4.0.1",
+				"zwitch": "^1.0.0"
+			}
+		},
+		"hastscript": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/hastscript/-/hastscript-3.1.0.tgz",
+			"integrity": "sha512-8V34dMSDT1Ik+ZSgTzCLdyp89MrWxcxctXPxhmb72GQj1Xkw1aHPM9UaHCWewvH2Q+PVkYUm4ZJVw4T0dgEGNA==",
+			"requires": {
+				"camelcase": "^3.0.0",
+				"comma-separated-tokens": "^1.0.0",
+				"hast-util-parse-selector": "^2.0.0",
+				"property-information": "^3.0.0",
+				"space-separated-tokens": "^1.0.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+				}
 			}
 		},
 		"hawk": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
 			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-			"dev": true,
 			"requires": {
 				"boom": "4.x.x",
 				"cryptiles": "3.x.x",
@@ -6611,7 +6170,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-			"dev": true,
 			"requires": {
 				"hash.js": "^1.0.3",
 				"minimalistic-assert": "^1.0.0",
@@ -6621,14 +6179,12 @@
 		"hoek": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
-			"dev": true
+			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
 		},
 		"home-or-tmp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.0",
 				"os-tmpdir": "^1.0.1"
@@ -6637,14 +6193,12 @@
 		"hosted-git-info": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
-			"dev": true
+			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
 		},
 		"hpack.js": {
 			"version": "2.1.6",
 			"resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
 			"integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"obuf": "^1.0.0",
@@ -6656,7 +6210,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
 			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
-			"dev": true,
 			"requires": {
 				"whatwg-encoding": "^1.0.1"
 			}
@@ -6664,14 +6217,17 @@
 		"html-entities": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
-			"integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
-			"dev": true
+			"integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
+		},
+		"html-void-elements": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.3.tgz",
+			"integrity": "sha512-SaGhCDPXJVNrQyKMtKy24q6IMdXg5FCPN3z+xizxw9l+oXQw5fOoaj/ERU5KqWhSYhXtW5bWthlDbTDLBhJQrA=="
 		},
 		"htmlparser2": {
 			"version": "3.9.2",
 			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
 			"integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
-			"dev": true,
 			"requires": {
 				"domelementtype": "^1.3.0",
 				"domhandler": "^2.3.0",
@@ -6684,14 +6240,12 @@
 		"http-deceiver": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
-			"integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
-			"dev": true
+			"integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
 		},
 		"http-errors": {
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
 			"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-			"dev": true,
 			"requires": {
 				"depd": "1.1.1",
 				"inherits": "2.0.3",
@@ -6703,7 +6257,6 @@
 			"version": "1.16.2",
 			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
 			"integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
-			"dev": true,
 			"requires": {
 				"eventemitter3": "1.x.x",
 				"requires-port": "1.x.x"
@@ -6713,7 +6266,6 @@
 			"version": "0.17.4",
 			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
 			"integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
-			"dev": true,
 			"requires": {
 				"http-proxy": "^1.16.2",
 				"is-glob": "^3.1.0",
@@ -6724,14 +6276,12 @@
 				"is-extglob": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-					"dev": true
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 				},
 				"is-glob": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^2.1.0"
 					}
@@ -6742,7 +6292,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
@@ -6753,7 +6302,6 @@
 			"version": "0.14.3",
 			"resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
 			"integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
-			"dev": true,
 			"requires": {
 				"is-ci": "^1.0.10",
 				"normalize-path": "^1.0.0",
@@ -6763,26 +6311,22 @@
 		"iconv-lite": {
 			"version": "0.4.19",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-			"dev": true
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
 		},
 		"ieee754": {
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-			"integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
-			"dev": true
+			"integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
 		},
 		"ignore": {
 			"version": "3.3.7",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-			"integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
-			"dev": true
+			"integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
 		},
 		"import-local": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
 			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
-			"dev": true,
 			"requires": {
 				"pkg-dir": "^2.0.0",
 				"resolve-cwd": "^2.0.0"
@@ -6791,14 +6335,12 @@
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-			"dev": true
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
 		},
 		"indent-string": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-			"dev": true,
 			"requires": {
 				"repeating": "^2.0.0"
 			}
@@ -6806,14 +6348,12 @@
 		"indexof": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
-			"dev": true
+			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
 		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -6822,20 +6362,17 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-			"dev": true
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-			"dev": true
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 		},
 		"inquirer": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-			"dev": true,
 			"requires": {
 				"ansi-escapes": "^3.0.0",
 				"chalk": "^2.0.0",
@@ -6856,14 +6393,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -6872,7 +6407,6 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -6882,14 +6416,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -6898,7 +6430,6 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -6909,7 +6440,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
 			"integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
-			"dev": true,
 			"requires": {
 				"meow": "^3.3.0"
 			}
@@ -6917,14 +6447,12 @@
 		"interpret": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-			"integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
-			"dev": true
+			"integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A="
 		},
 		"invariant": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
 			"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
@@ -6932,26 +6460,22 @@
 		"invert-kv": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-			"dev": true
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
 		},
 		"ip": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-			"dev": true
+			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
 		},
 		"ipaddr.js": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
-			"integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA=",
-			"dev": true
+			"integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA="
 		},
 		"is-accessor-descriptor": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 			"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-			"dev": true,
 			"requires": {
 				"kind-of": "^6.0.0"
 			},
@@ -6959,22 +6483,33 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
+			}
+		},
+		"is-alphabetical": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.2.tgz",
+			"integrity": "sha512-V0xN4BYezDHcBSKb1QHUFMlR4as/XEuCZBzMJUU4n7+Cbt33SmUnSol+pnXFvLxSHNq2CemUXNdaXV6Flg7+xg=="
+		},
+		"is-alphanumerical": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
+			"integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
+			"requires": {
+				"is-alphabetical": "^1.0.0",
+				"is-decimal": "^1.0.0"
 			}
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-			"dev": true
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
 		},
 		"is-binary-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-			"dev": true,
 			"requires": {
 				"binary-extensions": "^1.0.0"
 			}
@@ -6982,14 +6517,12 @@
 		"is-buffer": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-			"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-			"dev": true
+			"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-			"dev": true,
 			"requires": {
 				"builtin-modules": "^1.0.0"
 			}
@@ -6997,14 +6530,12 @@
 		"is-callable": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
-			"dev": true
+			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
 		},
 		"is-ci": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
 			"integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
-			"dev": true,
 			"requires": {
 				"ci-info": "^1.0.0"
 			}
@@ -7013,7 +6544,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 			"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-			"dev": true,
 			"requires": {
 				"kind-of": "^6.0.0"
 			},
@@ -7021,22 +6551,24 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
 		"is-date-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-			"dev": true
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+		},
+		"is-decimal": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.2.tgz",
+			"integrity": "sha512-TRzl7mOCchnhchN+f3ICUCzYvL9ul7R+TYOsZ8xia++knyZAJfv/uA1FvQXsAnYIl1T3B2X5E/J7Wb1QXiIBXg=="
 		},
 		"is-descriptor": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 			"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-			"dev": true,
 			"requires": {
 				"is-accessor-descriptor": "^1.0.0",
 				"is-data-descriptor": "^1.0.0",
@@ -7046,28 +6578,24 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
 		"is-directory": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
-			"dev": true
+			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-			"dev": true
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-			"dev": true,
 			"requires": {
 				"is-primitive": "^2.0.0"
 			}
@@ -7075,20 +6603,17 @@
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-			"dev": true
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
 		},
 		"is-extglob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-			"dev": true
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
 		},
 		"is-finite": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"dev": true,
 			"requires": {
 				"number-is-nan": "^1.0.0"
 			}
@@ -7096,29 +6621,38 @@
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-			"dev": true
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 		},
 		"is-generator-fn": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
-			"integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
-			"dev": true
+			"integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go="
 		},
 		"is-glob": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-			"dev": true,
 			"requires": {
 				"is-extglob": "^1.0.0"
+			}
+		},
+		"is-hexadecimal": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz",
+			"integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A=="
+		},
+		"is-nan": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.2.1.tgz",
+			"integrity": "sha1-n69ltvttskt/XAYoR16nH5iEAeI=",
+			"requires": {
+				"define-properties": "^1.1.1"
 			}
 		},
 		"is-number": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			}
@@ -7126,14 +6660,12 @@
 		"is-obj": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-			"dev": true
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
 		},
 		"is-observable": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
 			"integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
-			"dev": true,
 			"requires": {
 				"symbol-observable": "^0.2.2"
 			}
@@ -7142,7 +6674,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
 			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
-			"dev": true,
 			"requires": {
 				"is-number": "^4.0.0"
 			},
@@ -7150,22 +6681,19 @@
 				"is-number": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-					"dev": true
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
 				}
 			}
 		},
 		"is-path-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-			"dev": true
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
 		},
 		"is-path-in-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
 			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-			"dev": true,
 			"requires": {
 				"is-path-inside": "^1.0.0"
 			}
@@ -7174,7 +6702,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
 			"integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-			"dev": true,
 			"requires": {
 				"path-is-inside": "^1.0.1"
 			}
@@ -7182,14 +6709,12 @@
 		"is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-			"dev": true
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
 			},
@@ -7197,40 +6722,34 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
 		},
 		"is-posix-bracket": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-			"dev": true
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
 		},
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-			"dev": true
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
 		},
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-			"dev": true
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
 		},
 		"is-redirect": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-			"dev": true
+			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
 		},
 		"is-regex": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-			"dev": true,
 			"requires": {
 				"has": "^1.0.1"
 			}
@@ -7238,44 +6757,37 @@
 		"is-regexp": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-			"integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
-			"dev": true
+			"integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
 		},
 		"is-resolvable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
-			"dev": true
+			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
 		},
 		"is-retry-allowed": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-			"dev": true
+			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
 		},
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-			"dev": true
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
 		"is-subset": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
-			"dev": true
+			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY="
 		},
 		"is-symbol": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-			"dev": true
+			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
 		},
 		"is-text-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
 			"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
-			"dev": true,
 			"requires": {
 				"text-extensions": "^1.0.0"
 			}
@@ -7283,53 +6795,64 @@
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-			"dev": true
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
 		},
 		"is-utf8": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-			"dev": true
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+		},
+		"is-whitespace-character": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz",
+			"integrity": "sha512-SzM+T5GKUCtLhlHFKt2SDAX2RFzfS6joT91F2/WSi9LxgFdsnhfPK/UIA+JhRR2xuyLdrCys2PiFDrtn1fU5hQ=="
 		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-			"dev": true
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+		},
+		"is-word-character": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.2.tgz",
+			"integrity": "sha512-T3FlsX8rCHAH8e7RE7PfOPZVFQlcV3XRF9eOOBQ1uf70OxO7CjjSOjeImMPCADBdYWcStAbVbYvJ1m2D3tb+EA=="
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isobject": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-			"dev": true,
 			"requires": {
 				"isarray": "1.0.0"
+			}
+		},
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"requires": {
+				"node-fetch": "^1.0.1",
+				"whatwg-fetch": ">=0.10.0"
 			}
 		},
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-			"dev": true
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
 		"istanbul-api": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.1.tgz",
 			"integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
-			"dev": true,
 			"requires": {
 				"async": "^2.1.4",
 				"compare-versions": "^3.1.0",
@@ -7348,14 +6871,12 @@
 		"istanbul-lib-coverage": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
-			"integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==",
-			"dev": true
+			"integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A=="
 		},
 		"istanbul-lib-hook": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.0.tgz",
 			"integrity": "sha512-p3En6/oGkFQV55Up8ZPC2oLxvgSxD8CzA0yBrhRZSh3pfv3OFj9aSGVC0yoerAi/O4u7jUVnOGVX1eVFM+0tmQ==",
-			"dev": true,
 			"requires": {
 				"append-transform": "^0.4.0"
 			}
@@ -7364,7 +6885,6 @@
 			"version": "1.10.1",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
 			"integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
-			"dev": true,
 			"requires": {
 				"babel-generator": "^6.18.0",
 				"babel-template": "^6.16.0",
@@ -7379,7 +6899,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz",
 			"integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
-			"dev": true,
 			"requires": {
 				"istanbul-lib-coverage": "^1.2.0",
 				"mkdirp": "^0.5.1",
@@ -7390,14 +6909,12 @@
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-					"dev": true
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"dev": true,
 					"requires": {
 						"has-flag": "^1.0.0"
 					}
@@ -7408,7 +6925,6 @@
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz",
 			"integrity": "sha512-8O2T/3VhrQHn0XcJbP1/GN7kXMiRAlPi+fj3uEHrjBD8Oz7Py0prSC25C09NuAZS6bgW1NNKAvCSHZXB0irSGA==",
-			"dev": true,
 			"requires": {
 				"debug": "^3.1.0",
 				"istanbul-lib-coverage": "^1.2.0",
@@ -7421,7 +6937,6 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -7432,7 +6947,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.3.0.tgz",
 			"integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
-			"dev": true,
 			"requires": {
 				"handlebars": "^4.0.3"
 			}
@@ -7441,7 +6955,6 @@
 			"version": "23.1.0",
 			"resolved": "https://registry.npmjs.org/jest/-/jest-23.1.0.tgz",
 			"integrity": "sha1-u7f4kxAKEadC3YvQ0EelSwlorRo=",
-			"dev": true,
 			"requires": {
 				"import-local": "^1.0.0",
 				"jest-cli": "^23.1.0"
@@ -7450,14 +6963,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -7465,20 +6976,17 @@
 				"callsites": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-					"dev": true
+					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
 				},
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"chalk": {
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -7489,7 +6997,6 @@
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
 					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-					"dev": true,
 					"requires": {
 						"string-width": "^2.1.1",
 						"strip-ansi": "^4.0.0",
@@ -7500,7 +7007,6 @@
 					"version": "0.7.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
 						"get-stream": "^3.0.0",
@@ -7515,7 +7021,6 @@
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/expect/-/expect-23.1.0.tgz",
 					"integrity": "sha1-v9/VeiogFw2HWZnul4fMcfAcIF8=",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.0",
 						"jest-diff": "^23.0.1",
@@ -7528,14 +7033,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"jest-cli": {
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.1.0.tgz",
 					"integrity": "sha1-64vdTODRUlCJLjGtm2m8mdKo9r8=",
-					"dev": true,
 					"requires": {
 						"ansi-escapes": "^3.0.0",
 						"chalk": "^2.0.1",
@@ -7578,7 +7081,6 @@
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.1.0.tgz",
 					"integrity": "sha1-cIyg9DHTVu5CT7SJXTMIAGvdgkE=",
-					"dev": true,
 					"requires": {
 						"babel-core": "^6.0.0",
 						"babel-jest": "^23.0.1",
@@ -7599,7 +7101,6 @@
 					"version": "23.0.1",
 					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.0.1.tgz",
 					"integrity": "sha1-PUkTfO4SwyCktNK0pvpugtSRoWo=",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"diff": "^3.2.0",
@@ -7611,7 +7112,6 @@
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.1.0.tgz",
 					"integrity": "sha1-hZKZFOI77TV32sl1X0EG0Gl8R5w=",
-					"dev": true,
 					"requires": {
 						"jest-mock": "^23.1.0",
 						"jest-util": "^23.1.0",
@@ -7622,7 +7122,6 @@
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.1.0.tgz",
 					"integrity": "sha1-RSwL+UnPy7rNoeF2Lu7XC8eEx9U=",
-					"dev": true,
 					"requires": {
 						"jest-mock": "^23.1.0",
 						"jest-util": "^23.1.0"
@@ -7632,7 +7131,6 @@
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.1.0.tgz",
 					"integrity": "sha1-SvqzFym2VN3NKwdK3YSTlvE7MLg=",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"co": "^4.6.0",
@@ -7651,7 +7149,6 @@
 					"version": "23.0.1",
 					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.0.1.tgz",
 					"integrity": "sha1-DGwNrt+YM8Kn82I2Bp7+y0w/bl8=",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"jest-get-type": "^22.1.0",
@@ -7662,7 +7159,6 @@
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.1.0.tgz",
 					"integrity": "sha1-moCbpIfsrFzlEdTmmO47XuJGHqk=",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0-beta.35",
 						"chalk": "^2.0.1",
@@ -7674,20 +7170,17 @@
 				"jest-mock": {
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-23.1.0.tgz",
-					"integrity": "sha1-o4HDGxIasfYMRiotrbe4bczKxIc=",
-					"dev": true
+					"integrity": "sha1-o4HDGxIasfYMRiotrbe4bczKxIc="
 				},
 				"jest-regex-util": {
 					"version": "23.0.0",
 					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.0.0.tgz",
-					"integrity": "sha1-3Vwf3gxG9DcTFM8Q96dRoj9Oj3Y=",
-					"dev": true
+					"integrity": "sha1-3Vwf3gxG9DcTFM8Q96dRoj9Oj3Y="
 				},
 				"jest-resolve": {
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.1.0.tgz",
 					"integrity": "sha1-ueMW7s69bwC8UKOWDRUnuuZXktI=",
-					"dev": true,
 					"requires": {
 						"browser-resolve": "^1.11.2",
 						"chalk": "^2.0.1",
@@ -7698,7 +7191,6 @@
 					"version": "23.0.1",
 					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.0.1.tgz",
 					"integrity": "sha1-ZnT6Gbnraamcq+zUFb3cQtavPn4=",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"jest-diff": "^23.0.1",
@@ -7712,7 +7204,6 @@
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.1.0.tgz",
 					"integrity": "sha1-wCUbrzRkTG3S/qeKli9CY6xVdy0=",
-					"dev": true,
 					"requires": {
 						"callsites": "^2.0.0",
 						"chalk": "^2.0.1",
@@ -7728,7 +7219,6 @@
 					"version": "23.0.1",
 					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.0.1.tgz",
 					"integrity": "sha1-zZ8BqJ0mu4hfEqhmdxXpyGWldU8=",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"jest-get-type": "^22.1.0",
@@ -7740,7 +7230,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
 					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-					"dev": true,
 					"requires": {
 						"execa": "^0.7.0",
 						"lcid": "^1.0.0",
@@ -7751,7 +7240,6 @@
 					"version": "23.0.1",
 					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.0.1.tgz",
 					"integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0",
 						"ansi-styles": "^3.2.0"
@@ -7760,14 +7248,12 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -7776,7 +7262,6 @@
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -7784,14 +7269,12 @@
 				"which-module": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-					"dev": true
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 				},
 				"yargs": {
 					"version": "11.0.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
 					"integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
-					"dev": true,
 					"requires": {
 						"cliui": "^4.0.0",
 						"decamelize": "^1.1.1",
@@ -7811,7 +7294,6 @@
 					"version": "9.0.2",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
 					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0"
 					}
@@ -7822,7 +7304,6 @@
 			"version": "23.0.1",
 			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-23.0.1.tgz",
 			"integrity": "sha1-95Vy0HIIROpd+EwqRI6GLCJU9gw=",
-			"dev": true,
 			"requires": {
 				"throat": "^4.0.0"
 			}
@@ -7831,7 +7312,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.3.tgz",
 			"integrity": "sha512-KSg3EOToCgkX+lIvenKY7J8s426h6ahXxaUFJxvGoEk0562Z6inWj1TnKoGycTASwiLD+6kSYFALcjdosq9KIQ==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
 				"glob": "^7.1.1",
@@ -7850,7 +7330,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -7859,7 +7338,6 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -7869,14 +7347,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"supports-color": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -7887,7 +7363,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
 			"integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
 				"diff": "^3.2.0",
@@ -7899,7 +7374,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -7908,7 +7382,6 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -7918,14 +7391,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"supports-color": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -7936,7 +7407,6 @@
 			"version": "23.0.1",
 			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-23.0.1.tgz",
 			"integrity": "sha1-3t3RgzO+XcJBUmCgTvP86SdrVyU=",
-			"dev": true,
 			"requires": {
 				"detect-newline": "^2.1.0"
 			}
@@ -7945,7 +7415,6 @@
 			"version": "23.1.0",
 			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-23.1.0.tgz",
 			"integrity": "sha1-FhRrWSw1SGelrl4TzfFcbGW2lsY=",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
 				"pretty-format": "^23.0.1"
@@ -7954,14 +7423,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -7970,7 +7437,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -7980,14 +7446,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"pretty-format": {
 					"version": "23.0.1",
 					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.0.1.tgz",
 					"integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0",
 						"ansi-styles": "^3.2.0"
@@ -7997,7 +7461,6 @@
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -8008,7 +7471,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
 			"integrity": "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
-			"dev": true,
 			"requires": {
 				"jest-mock": "^22.4.3",
 				"jest-util": "^22.4.3",
@@ -8019,7 +7481,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.3.tgz",
 			"integrity": "sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==",
-			"dev": true,
 			"requires": {
 				"jest-mock": "^22.4.3",
 				"jest-util": "^22.4.3"
@@ -8028,14 +7489,12 @@
 		"jest-get-type": {
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
-			"integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
-			"dev": true
+			"integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w=="
 		},
 		"jest-haste-map": {
 			"version": "23.1.0",
 			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.1.0.tgz",
 			"integrity": "sha1-GObH1ajScTb5G32YUvhd4McHTEk=",
-			"dev": true,
 			"requires": {
 				"fb-watchman": "^2.0.0",
 				"graceful-fs": "^4.1.11",
@@ -8050,7 +7509,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.3.tgz",
 			"integrity": "sha512-yZCPCJUcEY6R5KJB/VReo1AYI2b+5Ky+C+JA1v34jndJsRcLpU4IZX4rFJn7yDTtdNbO/nNqg+3SDIPNH2ecnw==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
 				"co": "^4.6.0",
@@ -8069,7 +7527,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -8078,7 +7535,6 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -8088,20 +7544,17 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"source-map-support": {
 					"version": "0.5.4",
 					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.4.tgz",
 					"integrity": "sha512-PETSPG6BjY1AHs2t64vS2aqAgu6dMIMXJULWFBGbh2Gr8nVLbCFDo6i/RMMvviIQ2h1Z8+5gQhVKSn2je9nmdg==",
-					"dev": true,
 					"requires": {
 						"source-map": "^0.6.0"
 					}
@@ -8110,7 +7563,6 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -8121,7 +7573,6 @@
 			"version": "23.0.1",
 			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.0.1.tgz",
 			"integrity": "sha1-nboHUFrDSVw50+wJrB5WRZnoYaA=",
-			"dev": true,
 			"requires": {
 				"pretty-format": "^23.0.1"
 			},
@@ -8129,14 +7580,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -8145,7 +7594,6 @@
 					"version": "23.0.1",
 					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.0.1.tgz",
 					"integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0",
 						"ansi-styles": "^3.2.0"
@@ -8157,7 +7605,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
 			"integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
 				"jest-get-type": "^22.4.3",
@@ -8168,7 +7615,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -8177,7 +7623,6 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -8187,14 +7632,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"supports-color": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -8205,7 +7648,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
 			"integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0-beta.35",
 				"chalk": "^2.0.1",
@@ -8218,7 +7660,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -8227,7 +7668,6 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -8237,14 +7677,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"supports-color": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -8254,20 +7692,17 @@
 		"jest-mock": {
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.4.3.tgz",
-			"integrity": "sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q==",
-			"dev": true
+			"integrity": "sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q=="
 		},
 		"jest-regex-util": {
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.4.3.tgz",
-			"integrity": "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg==",
-			"dev": true
+			"integrity": "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg=="
 		},
 		"jest-resolve": {
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.3.tgz",
 			"integrity": "sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
-			"dev": true,
 			"requires": {
 				"browser-resolve": "^1.11.2",
 				"chalk": "^2.0.1"
@@ -8277,7 +7712,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -8286,7 +7720,6 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -8296,14 +7729,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"supports-color": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -8314,7 +7745,6 @@
 			"version": "23.0.1",
 			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.0.1.tgz",
 			"integrity": "sha1-0BoQ3a2RUsTOzfXqwriFccS2pk0=",
-			"dev": true,
 			"requires": {
 				"jest-regex-util": "^23.0.0",
 				"jest-snapshot": "^23.0.1"
@@ -8323,14 +7753,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -8339,7 +7767,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -8349,14 +7776,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"jest-diff": {
 					"version": "23.0.1",
 					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.0.1.tgz",
 					"integrity": "sha1-PUkTfO4SwyCktNK0pvpugtSRoWo=",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"diff": "^3.2.0",
@@ -8368,7 +7793,6 @@
 					"version": "23.0.1",
 					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.0.1.tgz",
 					"integrity": "sha1-DGwNrt+YM8Kn82I2Bp7+y0w/bl8=",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"jest-get-type": "^22.1.0",
@@ -8378,14 +7802,12 @@
 				"jest-regex-util": {
 					"version": "23.0.0",
 					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.0.0.tgz",
-					"integrity": "sha1-3Vwf3gxG9DcTFM8Q96dRoj9Oj3Y=",
-					"dev": true
+					"integrity": "sha1-3Vwf3gxG9DcTFM8Q96dRoj9Oj3Y="
 				},
 				"jest-snapshot": {
 					"version": "23.0.1",
 					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.0.1.tgz",
 					"integrity": "sha1-ZnT6Gbnraamcq+zUFb3cQtavPn4=",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"jest-diff": "^23.0.1",
@@ -8399,7 +7821,6 @@
 					"version": "23.0.1",
 					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.0.1.tgz",
 					"integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0",
 						"ansi-styles": "^3.2.0"
@@ -8409,7 +7830,6 @@
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -8420,7 +7840,6 @@
 			"version": "23.1.0",
 			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.1.0.tgz",
 			"integrity": "sha1-+iCpM//3MaVDKzVh5/ZCZZT6KbU=",
-			"dev": true,
 			"requires": {
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.1.11",
@@ -8440,14 +7859,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -8455,14 +7872,12 @@
 				"callsites": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-					"dev": true
+					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
 				},
 				"chalk": {
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -8473,7 +7888,6 @@
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/expect/-/expect-23.1.0.tgz",
 					"integrity": "sha1-v9/VeiogFw2HWZnul4fMcfAcIF8=",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.0",
 						"jest-diff": "^23.0.1",
@@ -8486,14 +7900,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"jest-config": {
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.1.0.tgz",
 					"integrity": "sha1-cIyg9DHTVu5CT7SJXTMIAGvdgkE=",
-					"dev": true,
 					"requires": {
 						"babel-core": "^6.0.0",
 						"babel-jest": "^23.0.1",
@@ -8514,7 +7926,6 @@
 					"version": "23.0.1",
 					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.0.1.tgz",
 					"integrity": "sha1-PUkTfO4SwyCktNK0pvpugtSRoWo=",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"diff": "^3.2.0",
@@ -8526,7 +7937,6 @@
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.1.0.tgz",
 					"integrity": "sha1-hZKZFOI77TV32sl1X0EG0Gl8R5w=",
-					"dev": true,
 					"requires": {
 						"jest-mock": "^23.1.0",
 						"jest-util": "^23.1.0",
@@ -8537,7 +7947,6 @@
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.1.0.tgz",
 					"integrity": "sha1-RSwL+UnPy7rNoeF2Lu7XC8eEx9U=",
-					"dev": true,
 					"requires": {
 						"jest-mock": "^23.1.0",
 						"jest-util": "^23.1.0"
@@ -8547,7 +7956,6 @@
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.1.0.tgz",
 					"integrity": "sha1-SvqzFym2VN3NKwdK3YSTlvE7MLg=",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"co": "^4.6.0",
@@ -8566,7 +7974,6 @@
 					"version": "23.0.1",
 					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.0.1.tgz",
 					"integrity": "sha1-DGwNrt+YM8Kn82I2Bp7+y0w/bl8=",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"jest-get-type": "^22.1.0",
@@ -8577,7 +7984,6 @@
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.1.0.tgz",
 					"integrity": "sha1-moCbpIfsrFzlEdTmmO47XuJGHqk=",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0-beta.35",
 						"chalk": "^2.0.1",
@@ -8589,20 +7995,17 @@
 				"jest-mock": {
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-23.1.0.tgz",
-					"integrity": "sha1-o4HDGxIasfYMRiotrbe4bczKxIc=",
-					"dev": true
+					"integrity": "sha1-o4HDGxIasfYMRiotrbe4bczKxIc="
 				},
 				"jest-regex-util": {
 					"version": "23.0.0",
 					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.0.0.tgz",
-					"integrity": "sha1-3Vwf3gxG9DcTFM8Q96dRoj9Oj3Y=",
-					"dev": true
+					"integrity": "sha1-3Vwf3gxG9DcTFM8Q96dRoj9Oj3Y="
 				},
 				"jest-resolve": {
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.1.0.tgz",
 					"integrity": "sha1-ueMW7s69bwC8UKOWDRUnuuZXktI=",
-					"dev": true,
 					"requires": {
 						"browser-resolve": "^1.11.2",
 						"chalk": "^2.0.1",
@@ -8613,7 +8016,6 @@
 					"version": "23.0.1",
 					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.0.1.tgz",
 					"integrity": "sha1-ZnT6Gbnraamcq+zUFb3cQtavPn4=",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"jest-diff": "^23.0.1",
@@ -8627,7 +8029,6 @@
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.1.0.tgz",
 					"integrity": "sha1-wCUbrzRkTG3S/qeKli9CY6xVdy0=",
-					"dev": true,
 					"requires": {
 						"callsites": "^2.0.0",
 						"chalk": "^2.0.1",
@@ -8643,7 +8044,6 @@
 					"version": "23.0.1",
 					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.0.1.tgz",
 					"integrity": "sha1-zZ8BqJ0mu4hfEqhmdxXpyGWldU8=",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"jest-get-type": "^22.1.0",
@@ -8655,7 +8055,6 @@
 					"version": "23.0.1",
 					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.0.1.tgz",
 					"integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0",
 						"ansi-styles": "^3.2.0"
@@ -8664,14 +8063,12 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"source-map-support": {
 					"version": "0.5.6",
 					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
 					"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
-					"dev": true,
 					"requires": {
 						"buffer-from": "^1.0.0",
 						"source-map": "^0.6.0"
@@ -8681,7 +8078,6 @@
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -8692,7 +8088,6 @@
 			"version": "23.1.0",
 			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.1.0.tgz",
 			"integrity": "sha1-tK4OhyWeys/UqIS2OdsHz03WIK8=",
-			"dev": true,
 			"requires": {
 				"babel-core": "^6.0.0",
 				"babel-plugin-istanbul": "^4.1.6",
@@ -8720,14 +8115,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -8735,20 +8128,17 @@
 				"callsites": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-					"dev": true
+					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
 				},
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"chalk": {
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -8759,7 +8149,6 @@
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
 					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-					"dev": true,
 					"requires": {
 						"string-width": "^2.1.1",
 						"strip-ansi": "^4.0.0",
@@ -8770,7 +8159,6 @@
 					"version": "0.7.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
 						"get-stream": "^3.0.0",
@@ -8785,7 +8173,6 @@
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/expect/-/expect-23.1.0.tgz",
 					"integrity": "sha1-v9/VeiogFw2HWZnul4fMcfAcIF8=",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.0",
 						"jest-diff": "^23.0.1",
@@ -8798,14 +8185,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"jest-config": {
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.1.0.tgz",
 					"integrity": "sha1-cIyg9DHTVu5CT7SJXTMIAGvdgkE=",
-					"dev": true,
 					"requires": {
 						"babel-core": "^6.0.0",
 						"babel-jest": "^23.0.1",
@@ -8826,7 +8211,6 @@
 					"version": "23.0.1",
 					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.0.1.tgz",
 					"integrity": "sha1-PUkTfO4SwyCktNK0pvpugtSRoWo=",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"diff": "^3.2.0",
@@ -8838,7 +8222,6 @@
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.1.0.tgz",
 					"integrity": "sha1-hZKZFOI77TV32sl1X0EG0Gl8R5w=",
-					"dev": true,
 					"requires": {
 						"jest-mock": "^23.1.0",
 						"jest-util": "^23.1.0",
@@ -8849,7 +8232,6 @@
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.1.0.tgz",
 					"integrity": "sha1-RSwL+UnPy7rNoeF2Lu7XC8eEx9U=",
-					"dev": true,
 					"requires": {
 						"jest-mock": "^23.1.0",
 						"jest-util": "^23.1.0"
@@ -8859,7 +8241,6 @@
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.1.0.tgz",
 					"integrity": "sha1-SvqzFym2VN3NKwdK3YSTlvE7MLg=",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"co": "^4.6.0",
@@ -8878,7 +8259,6 @@
 					"version": "23.0.1",
 					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.0.1.tgz",
 					"integrity": "sha1-DGwNrt+YM8Kn82I2Bp7+y0w/bl8=",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"jest-get-type": "^22.1.0",
@@ -8889,7 +8269,6 @@
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.1.0.tgz",
 					"integrity": "sha1-moCbpIfsrFzlEdTmmO47XuJGHqk=",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0-beta.35",
 						"chalk": "^2.0.1",
@@ -8901,20 +8280,17 @@
 				"jest-mock": {
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-23.1.0.tgz",
-					"integrity": "sha1-o4HDGxIasfYMRiotrbe4bczKxIc=",
-					"dev": true
+					"integrity": "sha1-o4HDGxIasfYMRiotrbe4bczKxIc="
 				},
 				"jest-regex-util": {
 					"version": "23.0.0",
 					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.0.0.tgz",
-					"integrity": "sha1-3Vwf3gxG9DcTFM8Q96dRoj9Oj3Y=",
-					"dev": true
+					"integrity": "sha1-3Vwf3gxG9DcTFM8Q96dRoj9Oj3Y="
 				},
 				"jest-resolve": {
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.1.0.tgz",
 					"integrity": "sha1-ueMW7s69bwC8UKOWDRUnuuZXktI=",
-					"dev": true,
 					"requires": {
 						"browser-resolve": "^1.11.2",
 						"chalk": "^2.0.1",
@@ -8925,7 +8301,6 @@
 					"version": "23.0.1",
 					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.0.1.tgz",
 					"integrity": "sha1-ZnT6Gbnraamcq+zUFb3cQtavPn4=",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"jest-diff": "^23.0.1",
@@ -8939,7 +8314,6 @@
 					"version": "23.1.0",
 					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.1.0.tgz",
 					"integrity": "sha1-wCUbrzRkTG3S/qeKli9CY6xVdy0=",
-					"dev": true,
 					"requires": {
 						"callsites": "^2.0.0",
 						"chalk": "^2.0.1",
@@ -8955,7 +8329,6 @@
 					"version": "23.0.1",
 					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.0.1.tgz",
 					"integrity": "sha1-zZ8BqJ0mu4hfEqhmdxXpyGWldU8=",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"jest-get-type": "^22.1.0",
@@ -8967,7 +8340,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
 					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-					"dev": true,
 					"requires": {
 						"execa": "^0.7.0",
 						"lcid": "^1.0.0",
@@ -8978,7 +8350,6 @@
 					"version": "23.0.1",
 					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.0.1.tgz",
 					"integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0",
 						"ansi-styles": "^3.2.0"
@@ -8987,14 +8358,12 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -9002,14 +8371,12 @@
 				"strip-bom": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-					"dev": true
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 				},
 				"supports-color": {
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -9017,14 +8384,12 @@
 				"which-module": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-					"dev": true
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 				},
 				"yargs": {
 					"version": "11.0.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
 					"integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
-					"dev": true,
 					"requires": {
 						"cliui": "^4.0.0",
 						"decamelize": "^1.1.1",
@@ -9044,7 +8409,6 @@
 					"version": "9.0.2",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
 					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0"
 					}
@@ -9054,14 +8418,12 @@
 		"jest-serializer": {
 			"version": "23.0.1",
 			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-23.0.1.tgz",
-			"integrity": "sha1-o3dq6zEekP6D+rnlM+hRAr0WQWU=",
-			"dev": true
+			"integrity": "sha1-o3dq6zEekP6D+rnlM+hRAr0WQWU="
 		},
 		"jest-snapshot": {
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.3.tgz",
 			"integrity": "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
 				"jest-diff": "^22.4.3",
@@ -9075,7 +8437,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -9084,7 +8445,6 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -9094,14 +8454,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"supports-color": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -9112,7 +8470,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
 			"integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
-			"dev": true,
 			"requires": {
 				"callsites": "^2.0.0",
 				"chalk": "^2.0.1",
@@ -9127,7 +8484,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -9135,14 +8491,12 @@
 				"callsites": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-					"dev": true
+					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
 				},
 				"chalk": {
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -9152,20 +8506,17 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"supports-color": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -9176,7 +8527,6 @@
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.3.tgz",
 			"integrity": "sha512-CfFM18W3GSP/xgmA4UouIx0ljdtfD2mjeBC6c89Gg17E44D4tQhAcTrZmf9djvipwU30kSTnk6CzcxdCCeSXfA==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
 				"jest-config": "^22.4.3",
@@ -9189,7 +8539,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -9198,7 +8547,6 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -9208,14 +8556,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"supports-color": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -9226,7 +8572,6 @@
 			"version": "23.1.0",
 			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-23.1.0.tgz",
 			"integrity": "sha1-qNWELjjZ+0r/+CPfartCpYrmzb0=",
-			"dev": true,
 			"requires": {
 				"ansi-escapes": "^3.0.0",
 				"chalk": "^2.0.1",
@@ -9237,7 +8582,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -9246,7 +8590,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -9256,14 +8599,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"supports-color": {
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -9274,22 +8615,30 @@
 			"version": "23.0.1",
 			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-23.0.1.tgz",
 			"integrity": "sha1-nmSd2WP/QEYCb5HEAX8Dmmqkp7w=",
-			"dev": true,
 			"requires": {
 				"merge-stream": "^1.0.1"
+			}
+		},
+		"js-beautify": {
+			"version": "1.7.5",
+			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.7.5.tgz",
+			"integrity": "sha512-9OhfAqGOrD7hoQBLJMTA+BKuKmoEtTJXzZ7WDF/9gvjtey1koVLuZqIY6c51aPDjbNdNtIXAkiWKVhziawE9Og==",
+			"requires": {
+				"config-chain": "~1.1.5",
+				"editorconfig": "^0.13.2",
+				"mkdirp": "~0.5.0",
+				"nopt": "~3.0.1"
 			}
 		},
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-			"dev": true
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
 		},
 		"js-yaml": {
 			"version": "3.9.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
 			"integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
-			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -9299,14 +8648,12 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"dev": true,
 			"optional": true
 		},
 		"jsdom": {
 			"version": "11.6.2",
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.6.2.tgz",
 			"integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
-			"dev": true,
 			"requires": {
 				"abab": "^1.0.4",
 				"acorn": "^5.3.0",
@@ -9339,58 +8686,49 @@
 				"acorn": {
 					"version": "5.5.3",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-					"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
-					"dev": true
+					"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
 				},
 				"parse5": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-					"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
-					"dev": true
+					"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
 				},
 				"xml-name-validator": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-					"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
-					"dev": true
+					"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
 				}
 			}
 		},
 		"jsesc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-			"dev": true
+			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
 		},
 		"json-loader": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
-			"integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
-			"dev": true
+			"integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w=="
 		},
 		"json-parse-better-errors": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
-			"integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
-			"dev": true
+			"integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw=="
 		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-			"dev": true
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
 		},
 		"json-schema-traverse": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-			"dev": true
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
 		},
 		"json-stable-stringify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-			"dev": true,
 			"requires": {
 				"jsonify": "~0.0.0"
 			}
@@ -9398,32 +8736,27 @@
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-			"dev": true
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-			"dev": true
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
 		"json3": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-			"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
-			"dev": true
+			"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
 		},
 		"json5": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-			"dev": true
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
 		},
 		"jsonfile": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
@@ -9431,20 +8764,17 @@
 		"jsonify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-			"dev": true
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
 		},
 		"jsonparse": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
-			"dev": true
+			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
 		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -9455,16 +8785,19 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-					"dev": true
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 				}
 			}
+		},
+		"kebab-case": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/kebab-case/-/kebab-case-1.0.0.tgz",
+			"integrity": "sha1-P55JkK3K0MaGwOcB92RYaPdfkes="
 		},
 		"kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-			"dev": true,
 			"requires": {
 				"is-buffer": "^1.1.5"
 			}
@@ -9472,14 +8805,12 @@
 		"lazy-cache": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-			"dev": true
+			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
 		},
 		"lcid": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-			"dev": true,
 			"requires": {
 				"invert-kv": "^1.0.0"
 			}
@@ -9487,14 +8818,12 @@
 		"left-pad": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
-			"integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4=",
-			"dev": true
+			"integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4="
 		},
 		"lerna": {
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/lerna/-/lerna-2.9.0.tgz",
 			"integrity": "sha512-8KvXqRsnkqkorOlE7tMnaDl8b43t8i6/ZyGthoyIzb7ikeH2XNrQOHuI1FWsuOtP2HY3vLp2zuMvM5Zuw3ulUA==",
-			"dev": true,
 			"requires": {
 				"async": "^1.5.0",
 				"chalk": "^2.1.0",
@@ -9541,7 +8870,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -9549,20 +8877,17 @@
 				"async": {
 					"version": "1.5.2",
 					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-					"dev": true
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 				},
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"chalk": {
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -9573,7 +8898,6 @@
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
 						"strip-ansi": "^3.0.1",
@@ -9584,7 +8908,6 @@
 							"version": "1.0.2",
 							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -9597,7 +8920,6 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
 					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-					"dev": true,
 					"requires": {
 						"is-glob": "^3.1.0",
 						"path-dirname": "^1.0.0"
@@ -9606,20 +8928,17 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"is-extglob": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-					"dev": true
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -9628,7 +8947,6 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^2.1.0"
 					}
@@ -9637,7 +8955,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^4.0.0",
@@ -9649,7 +8966,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
 					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-					"dev": true,
 					"requires": {
 						"execa": "^0.7.0",
 						"lcid": "^1.0.0",
@@ -9660,7 +8976,6 @@
 							"version": "0.7.0",
 							"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 							"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-							"dev": true,
 							"requires": {
 								"cross-spawn": "^5.0.1",
 								"get-stream": "^3.0.0",
@@ -9677,7 +8992,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
 						"json-parse-better-errors": "^1.0.1"
@@ -9687,7 +9001,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -9696,7 +9009,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^4.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -9707,7 +9019,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
 					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^2.0.0"
@@ -9717,7 +9028,6 @@
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
 							"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-							"dev": true,
 							"requires": {
 								"graceful-fs": "^4.1.2",
 								"parse-json": "^2.2.0",
@@ -9729,7 +9039,6 @@
 							"version": "2.2.0",
 							"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 							"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-							"dev": true,
 							"requires": {
 								"error-ex": "^1.2.0"
 							}
@@ -9738,7 +9047,6 @@
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
 							"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-							"dev": true,
 							"requires": {
 								"pify": "^2.0.0"
 							}
@@ -9746,14 +9054,12 @@
 						"pify": {
 							"version": "2.3.0",
 							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-							"dev": true
+							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 						},
 						"read-pkg": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
 							"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-							"dev": true,
 							"requires": {
 								"load-json-file": "^2.0.0",
 								"normalize-package-data": "^2.3.2",
@@ -9765,14 +9071,12 @@
 				"strip-bom": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-					"dev": true
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 				},
 				"supports-color": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -9780,14 +9084,12 @@
 				"which-module": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-					"dev": true
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 				},
 				"yargs": {
 					"version": "8.0.2",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
 					"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0",
 						"cliui": "^3.2.0",
@@ -9808,7 +9110,6 @@
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
 					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0"
 					}
@@ -9818,24 +9119,30 @@
 		"leven": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
-			"dev": true
+			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
 		},
 		"levn": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-			"dev": true,
 			"requires": {
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2"
+			}
+		},
+		"line-column": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/line-column/-/line-column-1.0.2.tgz",
+			"integrity": "sha1-0lryk2tvSEkXKzEuR5LR2Ye8NKI=",
+			"requires": {
+				"isarray": "^1.0.0",
+				"isobject": "^2.0.0"
 			}
 		},
 		"lint-staged": {
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-7.0.4.tgz",
 			"integrity": "sha512-9w4vwNJ1A7o4mwKhz/5B0VateS24KJjeU1ppO2UOBdbTg/iiypF4U6F3yckEms0Fbf5uvfLiPVp9pG2lBbVA6g==",
-			"dev": true,
 			"requires": {
 				"app-root-path": "^2.0.1",
 				"chalk": "^2.3.1",
@@ -9865,7 +9172,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -9873,20 +9179,17 @@
 				"arr-diff": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
 				},
 				"array-unique": {
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 				},
 				"braces": {
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"dev": true,
 					"requires": {
 						"arr-flatten": "^1.1.0",
 						"array-unique": "^0.3.2",
@@ -9904,7 +9207,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -9915,7 +9217,6 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -9926,7 +9227,6 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -9935,7 +9235,6 @@
 					"version": "0.9.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
 					"integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
-					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
 						"get-stream": "^3.0.0",
@@ -9950,7 +9249,6 @@
 					"version": "2.1.4",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"dev": true,
 					"requires": {
 						"debug": "^2.3.3",
 						"define-property": "^0.2.5",
@@ -9965,7 +9263,6 @@
 							"version": "2.6.9",
 							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-							"dev": true,
 							"requires": {
 								"ms": "2.0.0"
 							}
@@ -9974,7 +9271,6 @@
 							"version": "0.2.5",
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
@@ -9983,7 +9279,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -9992,7 +9287,6 @@
 							"version": "0.1.6",
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^0.1.6",
 								"is-data-descriptor": "^0.1.4",
@@ -10002,8 +9296,7 @@
 						"kind-of": {
 							"version": "5.1.0",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-							"dev": true
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 						}
 					}
 				},
@@ -10011,7 +9304,6 @@
 					"version": "2.0.4",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"dev": true,
 					"requires": {
 						"array-unique": "^0.3.2",
 						"define-property": "^1.0.0",
@@ -10027,7 +9319,6 @@
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
 							"requires": {
 								"is-descriptor": "^1.0.0"
 							}
@@ -10036,7 +9327,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -10047,7 +9337,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"dev": true,
 					"requires": {
 						"extend-shallow": "^2.0.1",
 						"is-number": "^3.0.0",
@@ -10059,7 +9348,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -10069,14 +9357,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"is-accessor-descriptor": {
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
@@ -10085,7 +9371,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -10096,7 +9381,6 @@
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
@@ -10105,7 +9389,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -10115,14 +9398,12 @@
 				"is-extglob": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-					"dev": true
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 				},
 				"is-glob": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^2.1.1"
 					}
@@ -10131,7 +9412,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
@@ -10140,7 +9420,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -10150,20 +9429,17 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				},
 				"micromatch": {
 					"version": "3.1.10",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"dev": true,
 					"requires": {
 						"arr-diff": "^4.0.0",
 						"array-unique": "^0.3.2",
@@ -10184,7 +9460,6 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -10195,7 +9470,6 @@
 			"version": "0.13.0",
 			"resolved": "https://registry.npmjs.org/listr/-/listr-0.13.0.tgz",
 			"integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
-			"dev": true,
 			"requires": {
 				"chalk": "^1.1.3",
 				"cli-truncate": "^0.2.1",
@@ -10220,7 +9494,6 @@
 					"version": "1.7.0",
 					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-					"dev": true,
 					"requires": {
 						"escape-string-regexp": "^1.0.5",
 						"object-assign": "^4.1.0"
@@ -10230,7 +9503,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-					"dev": true,
 					"requires": {
 						"chalk": "^1.0.0"
 					}
@@ -10240,14 +9512,12 @@
 		"listr-silent-renderer": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
-			"integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
-			"dev": true
+			"integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4="
 		},
 		"listr-update-renderer": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
 			"integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
-			"dev": true,
 			"requires": {
 				"chalk": "^1.1.3",
 				"cli-truncate": "^0.2.1",
@@ -10263,7 +9533,6 @@
 					"version": "1.7.0",
 					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-					"dev": true,
 					"requires": {
 						"escape-string-regexp": "^1.0.5",
 						"object-assign": "^4.1.0"
@@ -10272,14 +9541,12 @@
 				"indent-string": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-					"dev": true
+					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
 				},
 				"log-symbols": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-					"dev": true,
 					"requires": {
 						"chalk": "^1.0.0"
 					}
@@ -10290,7 +9557,6 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
 			"integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
-			"dev": true,
 			"requires": {
 				"chalk": "^1.1.3",
 				"cli-cursor": "^1.0.2",
@@ -10302,7 +9568,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-					"dev": true,
 					"requires": {
 						"restore-cursor": "^1.0.1"
 					}
@@ -10311,7 +9576,6 @@
 					"version": "1.7.0",
 					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-					"dev": true,
 					"requires": {
 						"escape-string-regexp": "^1.0.5",
 						"object-assign": "^4.1.0"
@@ -10320,14 +9584,12 @@
 				"onetime": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-					"dev": true
+					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
 				},
 				"restore-cursor": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-					"dev": true,
 					"requires": {
 						"exit-hook": "^1.0.0",
 						"onetime": "^1.0.0"
@@ -10339,7 +9601,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"parse-json": "^2.2.0",
@@ -10351,22 +9612,19 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				}
 			}
 		},
 		"loader-runner": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
-			"integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI=",
-			"dev": true
+			"integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI="
 		},
 		"loader-utils": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
 			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-			"dev": true,
 			"requires": {
 				"big.js": "^3.1.3",
 				"emojis-list": "^2.0.0",
@@ -10377,7 +9635,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-			"dev": true,
 			"requires": {
 				"p-locate": "^2.0.0",
 				"path-exists": "^3.0.0"
@@ -10386,104 +9643,92 @@
 		"lodash": {
 			"version": "4.17.5",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
-			"dev": true
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
 		},
 		"lodash._reinterpolate": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-			"dev": true
+			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
 		},
 		"lodash.assign": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-			"dev": true
+			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
 		},
 		"lodash.assignin": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
-			"integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI=",
-			"dev": true
+			"integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI="
 		},
 		"lodash.bind": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
-			"integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU=",
-			"dev": true
+			"integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
+		},
+		"lodash.clonedeep": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
 		},
 		"lodash.defaults": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-			"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
-			"dev": true
+			"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
 		},
 		"lodash.filter": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
-			"integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4=",
-			"dev": true
+			"integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
 		},
 		"lodash.flatten": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
-			"dev": true
+			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
 		},
 		"lodash.foreach": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
-			"integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
-			"dev": true
+			"integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
 		},
 		"lodash.map": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
-			"integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
-			"dev": true
+			"integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
 		},
 		"lodash.merge": {
 			"version": "4.6.1",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-			"integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
-			"dev": true
+			"integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
 		},
 		"lodash.pick": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-			"integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
-			"dev": true
+			"integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
 		},
 		"lodash.reduce": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
-			"integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs=",
-			"dev": true
+			"integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
 		},
 		"lodash.reject": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
-			"integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU=",
-			"dev": true
+			"integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU="
 		},
 		"lodash.some": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
-			"integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=",
-			"dev": true
+			"integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-			"dev": true
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
 		},
 		"lodash.template": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
 			"integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
-			"dev": true,
 			"requires": {
 				"lodash._reinterpolate": "~3.0.0",
 				"lodash.templatesettings": "^4.0.0"
@@ -10493,7 +9738,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
 			"integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
-			"dev": true,
 			"requires": {
 				"lodash._reinterpolate": "~3.0.0"
 			}
@@ -10502,7 +9746,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
 			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1"
 			},
@@ -10511,7 +9754,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -10520,7 +9762,6 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -10530,14 +9771,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"supports-color": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -10548,7 +9787,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
 			"integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
-			"dev": true,
 			"requires": {
 				"ansi-escapes": "^1.0.0",
 				"cli-cursor": "^1.0.2"
@@ -10557,14 +9795,12 @@
 				"ansi-escapes": {
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-					"dev": true
+					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
 				},
 				"cli-cursor": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-					"dev": true,
 					"requires": {
 						"restore-cursor": "^1.0.1"
 					}
@@ -10572,14 +9808,12 @@
 				"onetime": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-					"dev": true
+					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
 				},
 				"restore-cursor": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-					"dev": true,
 					"requires": {
 						"exit-hook": "^1.0.0",
 						"onetime": "^1.0.0"
@@ -10590,20 +9824,17 @@
 		"loglevel": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.4.1.tgz",
-			"integrity": "sha1-lbOD+Ro8J1b9SrCTZn5DCRYfK80=",
-			"dev": true
+			"integrity": "sha1-lbOD+Ro8J1b9SrCTZn5DCRYfK80="
 		},
 		"longest": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-			"dev": true
+			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
 		},
 		"loose-envify": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-			"dev": true,
 			"requires": {
 				"js-tokens": "^3.0.0"
 			}
@@ -10612,23 +9843,25 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-			"dev": true,
 			"requires": {
 				"currently-unhandled": "^0.4.1",
 				"signal-exit": "^3.0.0"
 			}
 		},
+		"lower-case": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+		},
 		"lowercase-keys": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-			"dev": true
+			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
 		},
 		"lru-cache": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
 			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-			"dev": true,
 			"requires": {
 				"pseudomap": "^1.0.2",
 				"yallist": "^2.1.2"
@@ -10638,7 +9871,6 @@
 			"version": "0.16.0",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.16.0.tgz",
 			"integrity": "sha1-lw67DacZMwEoX7GqZQ85vdgetFo=",
-			"dev": true,
 			"requires": {
 				"vlq": "^0.2.1"
 			}
@@ -10647,7 +9879,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
 			"integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
-			"dev": true,
 			"requires": {
 				"pify": "^3.0.0"
 			}
@@ -10656,7 +9887,6 @@
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
 			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
-			"dev": true,
 			"requires": {
 				"tmpl": "1.0.x"
 			}
@@ -10664,41 +9894,84 @@
 		"map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-			"dev": true
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
 		},
 		"map-obj": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-			"dev": true
+			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
 		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-			"dev": true,
 			"requires": {
 				"object-visit": "^1.0.0"
 			}
 		},
+		"mapz": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/mapz/-/mapz-1.0.2.tgz",
+			"integrity": "sha512-NuY43BoHy5K4jVg3/oD+g8ysNwdXY3HB5UankVWoikxT9YMqgCYC77pNRENTm/DfslLxPFEOyJUw9h9isRty6w==",
+			"requires": {
+				"x-is-array": "^0.1.0"
+			}
+		},
+		"markdown-escapes": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.2.tgz",
+			"integrity": "sha512-lbRZ2mE3Q9RtLjxZBZ9+IMl68DKIXaVAhwvwn9pmjnPLS0h/6kyBMgNhqi1xFJ/2yv6cSyv0jbiZavZv93JkkA=="
+		},
+		"mdast-util-definitions": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-1.2.2.tgz",
+			"integrity": "sha512-9NloPSwaB9f1PKcGqaScfqRf6zKOEjTIXVIbPOmgWI/JKxznlgVXC5C+8qgl3AjYg2vJBRgLYfLICaNiac89iA==",
+			"requires": {
+				"unist-util-visit": "^1.0.0"
+			}
+		},
+		"mdast-util-to-hast": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-3.0.1.tgz",
+			"integrity": "sha512-+eimV/12kdg0/T0EEfcK7IsDbSu2auVm92z5jdSEQ3DHF2HiU4OHmX9ir5wpQajr73nwabdxrUoxREvW2zVFFw==",
+			"requires": {
+				"collapse-white-space": "^1.0.0",
+				"detab": "^2.0.0",
+				"mdast-util-definitions": "^1.2.0",
+				"mdurl": "^1.0.1",
+				"trim": "0.0.1",
+				"trim-lines": "^1.0.0",
+				"unist-builder": "^1.0.1",
+				"unist-util-generated": "^1.1.0",
+				"unist-util-position": "^3.0.0",
+				"unist-util-visit": "^1.1.0",
+				"xtend": "^4.0.1"
+			}
+		},
+		"mdast-util-to-string": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.0.4.tgz",
+			"integrity": "sha1-XEVch4yTVfDB5/PotxnPWDaRrPs="
+		},
 		"mdn-data": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.1.tgz",
-			"integrity": "sha512-2J5JENcb4yD5AzBI4ilTakiq2P9gHSsi4LOygnMu/bkchgTiA63AjsHAhDc+3U36AJHRfcz30Qv6Tb7i/Qsiew==",
-			"dev": true
+			"integrity": "sha512-2J5JENcb4yD5AzBI4ilTakiq2P9gHSsi4LOygnMu/bkchgTiA63AjsHAhDc+3U36AJHRfcz30Qv6Tb7i/Qsiew=="
+		},
+		"mdurl": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+			"integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
 		},
 		"media-typer": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-			"dev": true
+			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
 		},
 		"mem": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-			"dev": true,
 			"requires": {
 				"mimic-fn": "^1.0.0"
 			}
@@ -10707,7 +9980,6 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
 			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-			"dev": true,
 			"requires": {
 				"errno": "^0.1.3",
 				"readable-stream": "^2.0.1"
@@ -10717,7 +9989,6 @@
 			"version": "3.7.0",
 			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-			"dev": true,
 			"requires": {
 				"camelcase-keys": "^2.0.0",
 				"decamelize": "^1.1.2",
@@ -10734,28 +10005,24 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
 		},
 		"merge": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
-			"dev": true
+			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
 		},
 		"merge-descriptors": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-			"dev": true
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
 		},
 		"merge-stream": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
 			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-			"dev": true,
 			"requires": {
 				"readable-stream": "^2.0.1"
 			}
@@ -10763,20 +10030,17 @@
 		"merge2": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.1.tgz",
-			"integrity": "sha512-wUqcG5pxrAcaFI1lkqkMnk3Q7nUxV/NWfpAFSeWUwG9TRODnBDCUHa75mi3o3vLWQ5N4CQERWCauSlP0I3ZqUg==",
-			"dev": true
+			"integrity": "sha512-wUqcG5pxrAcaFI1lkqkMnk3Q7nUxV/NWfpAFSeWUwG9TRODnBDCUHa75mi3o3vLWQ5N4CQERWCauSlP0I3ZqUg=="
 		},
 		"methods": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-			"dev": true
+			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
 		},
 		"micromatch": {
 			"version": "2.3.11",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-			"dev": true,
 			"requires": {
 				"arr-diff": "^2.0.0",
 				"array-unique": "^0.2.1",
@@ -10797,7 +10061,6 @@
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-					"dev": true,
 					"requires": {
 						"remove-trailing-separator": "^1.0.1"
 					}
@@ -10808,7 +10071,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
 			"integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.0.0",
 				"brorand": "^1.0.1"
@@ -10817,20 +10079,17 @@
 		"mime": {
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-			"integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
-			"dev": true
+			"integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
 		},
 		"mime-db": {
 			"version": "1.29.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
-			"integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg=",
-			"dev": true
+			"integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg="
 		},
 		"mime-types": {
 			"version": "2.1.16",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
 			"integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
-			"dev": true,
 			"requires": {
 				"mime-db": "~1.29.0"
 			}
@@ -10838,14 +10097,12 @@
 		"mimic-fn": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-			"integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
-			"dev": true
+			"integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
 		},
 		"min-document": {
 			"version": "2.19.0",
 			"resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
 			"integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-			"dev": true,
 			"requires": {
 				"dom-walk": "^0.1.0"
 			}
@@ -10853,20 +10110,17 @@
 		"minimalistic-assert": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
-			"integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M=",
-			"dev": true
+			"integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
 		},
 		"minimalistic-crypto-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
-			"dev": true
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
 		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -10874,14 +10128,12 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-			"dev": true
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"minimist-options": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
 			"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
-			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1",
 				"is-plain-obj": "^1.1.0"
@@ -10891,7 +10143,6 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
-			"dev": true,
 			"requires": {
 				"for-in": "^1.0.2",
 				"is-extendable": "^1.0.1"
@@ -10901,7 +10152,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"dev": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
@@ -10912,7 +10162,6 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -10920,26 +10169,22 @@
 		"modify-values": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
-			"integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
-			"dev": true
+			"integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw=="
 		},
 		"moment": {
 			"version": "2.21.0",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
-			"integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ==",
-			"dev": true
+			"integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
 		},
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-			"dev": true
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
 		"multicast-dns": {
 			"version": "6.1.1",
 			"resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.1.1.tgz",
 			"integrity": "sha1-bn3oalcIcqsXBYrepxYLvsqBTd4=",
-			"dev": true,
 			"requires": {
 				"dns-packet": "^1.0.1",
 				"thunky": "^0.1.0"
@@ -10948,27 +10193,23 @@
 		"multicast-dns-service-types": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
-			"integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
-			"dev": true
+			"integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
 		},
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-			"dev": true
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
 		},
 		"nan": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
 			"integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
-			"dev": true,
 			"optional": true
 		},
 		"nanomatch": {
 			"version": "1.2.9",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
 			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
-			"dev": true,
 			"requires": {
 				"arr-diff": "^4.0.0",
 				"array-unique": "^0.3.2",
@@ -10987,61 +10228,69 @@
 				"arr-diff": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
 				},
 				"array-unique": {
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-			"dev": true
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
 		},
 		"negotiator": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
-			"dev": true
+			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
 		},
 		"nested-error-stacks": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.0.0.tgz",
 			"integrity": "sha1-mLL/rvtGEPo5NvHnFDXTBwDeKEA=",
-			"dev": true,
 			"requires": {
 				"inherits": "~2.0.1"
+			}
+		},
+		"no-case": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+			"integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+			"requires": {
+				"lower-case": "^1.1.1"
+			}
+		},
+		"node-fetch": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"requires": {
+				"encoding": "^0.1.11",
+				"is-stream": "^1.0.1"
 			}
 		},
 		"node-forge": {
 			"version": "0.6.33",
 			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.33.tgz",
-			"integrity": "sha1-RjgRh59XPUUVWtap9D3ClujoXrw=",
-			"dev": true
+			"integrity": "sha1-RjgRh59XPUUVWtap9D3ClujoXrw="
 		},
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
-			"dev": true
+			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
 		},
 		"node-libs-browser": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
 			"integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
-			"dev": true,
 			"requires": {
 				"assert": "^1.1.1",
 				"browserify-zlib": "^0.1.4",
@@ -11072,7 +10321,6 @@
 					"version": "4.9.1",
 					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
 					"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-					"dev": true,
 					"requires": {
 						"base64-js": "^1.0.2",
 						"ieee754": "^1.1.4",
@@ -11082,26 +10330,22 @@
 				"https-browserify": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
-					"integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
-					"dev": true
+					"integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI="
 				},
 				"os-browserify": {
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
-					"integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8=",
-					"dev": true
+					"integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8="
 				},
 				"string_decoder": {
 					"version": "0.10.31",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				},
 				"timers-browserify": {
 					"version": "2.0.3",
 					"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.3.tgz",
 					"integrity": "sha512-+JAqyNgg+M8+gXIrq2EeUr4kZqRz47Ysco7X5QKRGScRE9HIHckyHD1asozSFGeqx2nmPCgA8T5tIGVO0ML7/w==",
-					"dev": true,
 					"requires": {
 						"global": "^4.3.2",
 						"setimmediate": "^1.0.4"
@@ -11113,7 +10357,6 @@
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
 			"integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
-			"dev": true,
 			"requires": {
 				"growly": "^1.3.0",
 				"semver": "^5.4.1",
@@ -11121,11 +10364,18 @@
 				"which": "^1.3.0"
 			}
 		},
+		"nopt": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+			"requires": {
+				"abbrev": "1"
+			}
+		},
 		"normalize-package-data": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.1.4",
 				"is-builtin-module": "^1.0.0",
@@ -11136,20 +10386,17 @@
 		"normalize-path": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
-			"integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
-			"dev": true
+			"integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k="
 		},
 		"normalize-range": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
-			"dev": true
+			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
 		},
 		"npm-path": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
 			"integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
-			"dev": true,
 			"requires": {
 				"which": "^1.2.10"
 			}
@@ -11158,7 +10405,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-			"dev": true,
 			"requires": {
 				"path-key": "^2.0.0"
 			}
@@ -11167,7 +10413,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
 			"integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
-			"dev": true,
 			"requires": {
 				"commander": "^2.9.0",
 				"npm-path": "^2.0.2",
@@ -11178,7 +10423,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"dev": true,
 			"requires": {
 				"are-we-there-yet": "~1.1.2",
 				"console-control-strings": "~1.1.0",
@@ -11190,7 +10434,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
 			"integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
-			"dev": true,
 			"requires": {
 				"boolbase": "~1.0.0"
 			}
@@ -11198,38 +10441,32 @@
 		"num2fraction": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-			"integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
-			"dev": true
+			"integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
 		},
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-			"dev": true
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
 		"nwmatcher": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
-			"integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
-			"dev": true
+			"integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ=="
 		},
 		"oauth-sign": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-			"dev": true
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
 		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"dev": true
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-copy": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-			"dev": true,
 			"requires": {
 				"copy-descriptor": "^0.1.0",
 				"define-property": "^0.2.5",
@@ -11240,7 +10477,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -11249,7 +10485,6 @@
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
@@ -11258,7 +10493,6 @@
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
@@ -11267,7 +10501,6 @@
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^0.1.6",
 						"is-data-descriptor": "^0.1.4",
@@ -11277,8 +10510,7 @@
 						"kind-of": {
 							"version": "5.1.0",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-							"dev": true
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 						}
 					}
 				}
@@ -11287,14 +10519,12 @@
 		"object-keys": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
-			"dev": true
+			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
 		},
 		"object-visit": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-			"dev": true,
 			"requires": {
 				"isobject": "^3.0.0"
 			},
@@ -11302,8 +10532,7 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
 		},
@@ -11311,7 +10540,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
 			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.5.1"
@@ -11321,7 +10549,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-			"dev": true,
 			"requires": {
 				"for-own": "^0.1.4",
 				"is-extendable": "^0.1.1"
@@ -11331,7 +10558,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
 			},
@@ -11339,8 +10565,7 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
 		},
@@ -11348,7 +10573,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
 			"integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"es-abstract": "^1.6.1",
@@ -11359,14 +10583,12 @@
 		"obuf": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.1.tgz",
-			"integrity": "sha1-EEEktsYCxnlogaBCVB0220OlJk4=",
-			"dev": true
+			"integrity": "sha1-EEEktsYCxnlogaBCVB0220OlJk4="
 		},
 		"on-finished": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
 			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-			"dev": true,
 			"requires": {
 				"ee-first": "1.1.1"
 			}
@@ -11374,14 +10596,12 @@
 		"on-headers": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-			"integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
-			"dev": true
+			"integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
 		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -11390,7 +10610,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-			"dev": true,
 			"requires": {
 				"mimic-fn": "^1.0.0"
 			}
@@ -11399,7 +10618,6 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-			"dev": true,
 			"requires": {
 				"minimist": "~0.0.1",
 				"wordwrap": "~0.0.2"
@@ -11408,8 +10626,7 @@
 				"wordwrap": {
 					"version": "0.0.3",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-					"dev": true
+					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
 				}
 			}
 		},
@@ -11417,7 +10634,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/optimize-js/-/optimize-js-1.0.3.tgz",
 			"integrity": "sha1-QyavhlfEpf8y2vcmYxdU9yq3/bw=",
-			"dev": true,
 			"requires": {
 				"acorn": "^3.3.0",
 				"concat-stream": "^1.5.1",
@@ -11429,8 +10645,7 @@
 				"acorn": {
 					"version": "3.3.0",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-					"dev": true
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
 				}
 			}
 		},
@@ -11438,7 +10653,6 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-			"dev": true,
 			"requires": {
 				"deep-is": "~0.1.3",
 				"fast-levenshtein": "~2.0.4",
@@ -11452,7 +10666,6 @@
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
 			"integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
-			"dev": true,
 			"requires": {
 				"chalk": "^1.1.1",
 				"cli-cursor": "^1.0.2",
@@ -11464,7 +10677,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-					"dev": true,
 					"requires": {
 						"restore-cursor": "^1.0.1"
 					}
@@ -11472,14 +10684,12 @@
 				"onetime": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-					"dev": true
+					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
 				},
 				"restore-cursor": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-					"dev": true,
 					"requires": {
 						"exit-hook": "^1.0.0",
 						"onetime": "^1.0.0"
@@ -11491,7 +10701,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
 			"integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
-			"dev": true,
 			"requires": {
 				"url-parse": "1.0.x"
 			},
@@ -11500,7 +10709,6 @@
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
 					"integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
-					"dev": true,
 					"requires": {
 						"querystringify": "0.0.x",
 						"requires-port": "1.0.x"
@@ -11511,14 +10719,12 @@
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-			"dev": true
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 		},
 		"os-locale": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-			"dev": true,
 			"requires": {
 				"lcid": "^1.0.0"
 			}
@@ -11526,26 +10732,22 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-			"dev": true
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
 		},
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-			"dev": true
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
 		"p-limit": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-			"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-			"dev": true
+			"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
 		},
 		"p-locate": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-			"dev": true,
 			"requires": {
 				"p-limit": "^1.1.0"
 			}
@@ -11553,20 +10755,17 @@
 		"p-map": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.1.1.tgz",
-			"integrity": "sha1-BfXkrpegaDcbwqXMhr+9vBnErno=",
-			"dev": true
+			"integrity": "sha1-BfXkrpegaDcbwqXMhr+9vBnErno="
 		},
 		"p-queue": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-2.4.0.tgz",
-			"integrity": "sha512-ZXisZuQjnDcRd4/Np7lNrE2f3qq2Cy8Ikg8T2gbLjQZbRnSVqOr9cQUMbyVJJuIDUJYWMOZ+Q/5fJbYJtMbZ2A==",
-			"dev": true
+			"integrity": "sha512-ZXisZuQjnDcRd4/Np7lNrE2f3qq2Cy8Ikg8T2gbLjQZbRnSVqOr9cQUMbyVJJuIDUJYWMOZ+Q/5fJbYJtMbZ2A=="
 		},
 		"package-json": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
 			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-			"dev": true,
 			"requires": {
 				"got": "^6.7.1",
 				"registry-auth-token": "^3.0.1",
@@ -11577,14 +10776,12 @@
 		"pako": {
 			"version": "0.2.9",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-			"integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
-			"dev": true
+			"integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
 		},
 		"parse-asn1": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
 			"integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
-			"dev": true,
 			"requires": {
 				"asn1.js": "^4.0.0",
 				"browserify-aes": "^1.0.0",
@@ -11593,17 +10790,28 @@
 				"pbkdf2": "^3.0.3"
 			}
 		},
+		"parse-entities": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.2.tgz",
+			"integrity": "sha512-5N9lmQ7tmxfXf+hO3X6KRG6w7uYO/HL9fHalSySTdyn63C3WNvTM/1R8tn1u1larNcEbo3Slcy2bsVDQqvEpUg==",
+			"requires": {
+				"character-entities": "^1.0.0",
+				"character-entities-legacy": "^1.0.0",
+				"character-reference-invalid": "^1.0.0",
+				"is-alphanumerical": "^1.0.0",
+				"is-decimal": "^1.0.0",
+				"is-hexadecimal": "^1.0.0"
+			}
+		},
 		"parse-github-repo-url": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
-			"integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
-			"dev": true
+			"integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A="
 		},
 		"parse-glob": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-			"dev": true,
 			"requires": {
 				"glob-base": "^0.3.0",
 				"is-dotfile": "^1.0.0",
@@ -11615,76 +10823,78 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-			"dev": true,
 			"requires": {
 				"error-ex": "^1.2.0"
 			}
 		},
+		"parse5": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+		},
 		"parseurl": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-			"integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY=",
-			"dev": true
+			"integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
+		},
+		"pascal-case": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
+			"integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
+			"requires": {
+				"camel-case": "^3.0.0",
+				"upper-case-first": "^1.1.0"
+			}
 		},
 		"pascalcase": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-			"dev": true
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
 		},
 		"path-browserify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
-			"dev": true
+			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
 		},
 		"path-dirname": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-			"dev": true
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
 		},
 		"path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-			"dev": true
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-			"dev": true
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
 		},
 		"path-key": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-			"dev": true
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
 		},
 		"path-parse": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-			"dev": true
+			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
 		},
 		"path-to-regexp": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-			"dev": true
+			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
 		},
 		"path-type": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"pify": "^2.0.0",
@@ -11694,8 +10904,7 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				}
 			}
 		},
@@ -11703,7 +10912,6 @@
 			"version": "3.0.13",
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.13.tgz",
 			"integrity": "sha512-+dCHxDH+djNtjgWmvVC/my3SYBAKpKNqKSjLkp+GtWWYe4XPE+e/PSD2aCanlEZZnqPk2uekTKNC/ccbwd2X2Q==",
-			"dev": true,
 			"requires": {
 				"create-hash": "^1.1.2",
 				"create-hmac": "^1.1.4",
@@ -11715,26 +10923,22 @@
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-			"dev": true
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
 		"pify": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-			"dev": true
+			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 		},
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-			"dev": true
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-			"dev": true,
 			"requires": {
 				"pinkie": "^2.0.0"
 			}
@@ -11743,7 +10947,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
 			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-			"dev": true,
 			"requires": {
 				"find-up": "^2.1.0"
 			}
@@ -11751,26 +10954,22 @@
 		"please-upgrade-node": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.0.1.tgz",
-			"integrity": "sha1-CmgfLBiRXlQzpcos2U4Lggangts=",
-			"dev": true
+			"integrity": "sha1-CmgfLBiRXlQzpcos2U4Lggangts="
 		},
 		"pluralize": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-			"dev": true
+			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
 		},
 		"pn": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
-			"dev": true
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
 		},
 		"portfinder": {
 			"version": "1.0.13",
 			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
 			"integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
-			"dev": true,
 			"requires": {
 				"async": "^1.5.2",
 				"debug": "^2.2.0",
@@ -11780,22 +10979,19 @@
 				"async": {
 					"version": "1.5.2",
 					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-					"dev": true
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 				}
 			}
 		},
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-			"dev": true
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
 		},
 		"postcss": {
 			"version": "6.0.21",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
 			"integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.3.2",
 				"source-map": "^0.6.1",
@@ -11806,7 +11002,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -11815,7 +11010,6 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -11825,20 +11019,17 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"supports-color": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -11849,7 +11040,6 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-6.0.0.tgz",
 			"integrity": "sha1-vlMnhBEOyylQRPtTlaGABushpzc=",
-			"dev": true,
 			"requires": {
 				"postcss": "^6.0.1"
 			}
@@ -11858,17 +11048,24 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-7.0.0.tgz",
 			"integrity": "sha512-dl/CNaM6z2RBa0vZZqsV6Hunj4HD6Spu7FcAkiVp5B2tgm6xReKKYzI7x7QNx3wTMBNj5v+ylfVcQGMW4xdkHw==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"postcss": "^6.0.18"
+			}
+		},
+		"postcss-js": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-1.0.1.tgz",
+			"integrity": "sha512-smhUUMF5o5W1ZCQSyh5A3lNOXFLdNrxqyhWbLsGolZH2AgVmlyhxhYbIixfsdKE6r1vG5i7O40DPcvEvE1mvjw==",
+			"requires": {
+				"camelcase-css": "^1.0.1",
+				"postcss": "^6.0.11"
 			}
 		},
 		"postcss-reporter": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-5.0.0.tgz",
 			"integrity": "sha512-rBkDbaHAu5uywbCR2XE8a25tats3xSOsGNx6mppK6Q9kSFGKc/FyAzfci+fWM2l+K402p1D0pNcfDGxeje5IKg==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
 				"lodash": "^4.17.4",
@@ -11880,7 +11077,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -11889,7 +11085,6 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -11899,14 +11094,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"supports-color": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -11916,38 +11109,32 @@
 		"postcss-value-parser": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
-			"integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
-			"dev": true
+			"integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-			"dev": true
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
 		},
 		"prepend-http": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-			"dev": true
+			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
 		},
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-			"dev": true
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
 		},
 		"prettier": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.11.1.tgz",
-			"integrity": "sha512-T/KD65Ot0PB97xTrG8afQ46x3oiVhnfGjGESSI9NWYcG92+OUPZKkwHqGWXH2t9jK1crnQjubECW0FuOth+hxw==",
-			"dev": true
+			"integrity": "sha512-T/KD65Ot0PB97xTrG8afQ46x3oiVhnfGjGESSI9NWYcG92+OUPZKkwHqGWXH2t9jK1crnQjubECW0FuOth+hxw=="
 		},
 		"pretty-format": {
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
 			"integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "^3.0.0",
 				"ansi-styles": "^3.2.0"
@@ -11956,14 +11143,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -11973,32 +11158,55 @@
 		"private": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-			"integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE=",
-			"dev": true
+			"integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE="
 		},
 		"process": {
 			"version": "0.11.10",
 			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-			"dev": true
+			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
 		},
 		"process-nextick-args": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-			"dev": true
+			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
 		},
 		"progress": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
-			"dev": true
+			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
+		},
+		"promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"requires": {
+				"asap": "~2.0.3"
+			}
+		},
+		"prop-types": {
+			"version": "15.6.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+			"requires": {
+				"fbjs": "^0.8.16",
+				"loose-envify": "^1.3.1",
+				"object-assign": "^4.1.1"
+			}
+		},
+		"property-information": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/property-information/-/property-information-3.2.0.tgz",
+			"integrity": "sha1-/RSDyPusYYCPX+NZ52k6H0ilgzE="
+		},
+		"proto-list": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
 		},
 		"proxy-addr": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
 			"integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
-			"dev": true,
 			"requires": {
 				"forwarded": "~0.1.0",
 				"ipaddr.js": "1.4.0"
@@ -12007,20 +11215,17 @@
 		"prr": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-			"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
-			"dev": true
+			"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
 		},
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-			"dev": true
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
 		"public-encrypt": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
 			"integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
-			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.0",
 				"browserify-rsa": "^4.0.0",
@@ -12032,50 +11237,42 @@
 		"punycode": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-			"dev": true
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
 		},
 		"q": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-			"dev": true
+			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
 		},
 		"qs": {
 			"version": "6.4.0",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-			"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-			"dev": true
+			"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
 		},
 		"querystring": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-			"dev": true
+			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
 		},
 		"querystring-es3": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
-			"dev": true
+			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
 		},
 		"querystringify": {
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
-			"integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw=",
-			"dev": true
+			"integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw="
 		},
 		"quick-lru": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
-			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
-			"dev": true
+			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
 		},
 		"randomatic": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-			"dev": true,
 			"requires": {
 				"is-number": "^3.0.0",
 				"kind-of": "^4.0.0"
@@ -12085,7 +11282,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
@@ -12094,7 +11290,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -12105,7 +11300,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -12116,7 +11310,6 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
 			"integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -12124,14 +11317,12 @@
 		"range-parser": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
-			"dev": true
+			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
 		},
 		"rc": {
 			"version": "1.2.6",
 			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
 			"integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
-			"dev": true,
 			"requires": {
 				"deep-extend": "~0.4.0",
 				"ini": "~1.3.0",
@@ -12142,16 +11333,41 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
+			}
+		},
+		"react": {
+			"version": "16.4.1",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.4.1.tgz",
+			"integrity": "sha512-3GEs0giKp6E0Oh/Y9ZC60CmYgUPnp7voH9fbjWsvXtYFb4EWtgQub0ADSq0sJR0BbHc4FThLLtzlcFaFXIorwg==",
+			"requires": {
+				"fbjs": "^0.8.16",
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.0"
+			}
+		},
+		"react-attr-converter": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/react-attr-converter/-/react-attr-converter-0.3.1.tgz",
+			"integrity": "sha512-dSxo2Mn6Zx4HajeCeQNLefwEO4kNtV/0E682R1+ZTyFRPqxDa5zYb5qM/ocqw9Bxr/kFQO0IUiqdV7wdHw+Cdg=="
+		},
+		"react-dom": {
+			"version": "16.4.1",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.1.tgz",
+			"integrity": "sha512-1Gin+wghF/7gl4Cqcvr1DxFX2Osz7ugxSwl6gBqCMpdrxHjIFUS7GYxrFftZ9Ln44FHw0JxCFD9YtZsrbR5/4A==",
+			"requires": {
+				"fbjs": "^0.8.16",
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.0"
 			}
 		},
 		"read-cmd-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
 			"integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2"
 			}
@@ -12160,7 +11376,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-			"dev": true,
 			"requires": {
 				"load-json-file": "^1.0.0",
 				"normalize-package-data": "^2.3.2",
@@ -12171,7 +11386,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-			"dev": true,
 			"requires": {
 				"find-up": "^1.0.0",
 				"read-pkg": "^1.0.0"
@@ -12181,7 +11395,6 @@
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"dev": true,
 					"requires": {
 						"path-exists": "^2.0.0",
 						"pinkie-promise": "^2.0.0"
@@ -12191,7 +11404,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"dev": true,
 					"requires": {
 						"pinkie-promise": "^2.0.0"
 					}
@@ -12202,7 +11414,6 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
 			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -12217,7 +11428,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"minimatch": "^3.0.2",
@@ -12229,7 +11439,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.0.tgz",
 			"integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
-			"dev": true,
 			"requires": {
 				"util.promisify": "^1.0.0"
 			}
@@ -12238,7 +11447,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
 			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-			"dev": true,
 			"requires": {
 				"indent-string": "^2.1.0",
 				"strip-indent": "^1.0.1"
@@ -12248,7 +11456,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
 					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-					"dev": true,
 					"requires": {
 						"get-stdin": "^4.0.1"
 					}
@@ -12258,20 +11465,17 @@
 		"regenerate": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-			"integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA=",
-			"dev": true
+			"integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA="
 		},
 		"regenerator-runtime": {
 			"version": "0.10.5",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-			"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
-			"dev": true
+			"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
 		},
 		"regenerator-transform": {
 			"version": "0.9.11",
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
 			"integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.18.0",
 				"babel-types": "^6.19.0",
@@ -12282,7 +11486,6 @@
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
 			"integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-			"dev": true,
 			"requires": {
 				"is-equal-shallow": "^0.1.3",
 				"is-primitive": "^2.0.0"
@@ -12292,7 +11495,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.2",
 				"safe-regex": "^1.1.0"
@@ -12301,14 +11503,12 @@
 		"regexpp": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.0.1.tgz",
-			"integrity": "sha512-8Ph721maXiOYSLtaDGKVmDn5wdsNaF6Px85qFNeMPQq0r8K5Y10tgP6YuR65Ws35n4DvzFcCxEnRNBIXQunzLw==",
-			"dev": true
+			"integrity": "sha512-8Ph721maXiOYSLtaDGKVmDn5wdsNaF6Px85qFNeMPQq0r8K5Y10tgP6YuR65Ws35n4DvzFcCxEnRNBIXQunzLw=="
 		},
 		"regexpu-core": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-			"dev": true,
 			"requires": {
 				"regenerate": "^1.2.1",
 				"regjsgen": "^0.2.0",
@@ -12319,7 +11519,6 @@
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
 			"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
-			"dev": true,
 			"requires": {
 				"rc": "^1.1.6",
 				"safe-buffer": "^5.0.1"
@@ -12329,7 +11528,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
 			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-			"dev": true,
 			"requires": {
 				"rc": "^1.0.1"
 			}
@@ -12337,14 +11535,12 @@
 		"regjsgen": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-			"dev": true
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
 		},
 		"regjsparser": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-			"dev": true,
 			"requires": {
 				"jsesc": "~0.5.0"
 			},
@@ -12352,43 +11548,90 @@
 				"jsesc": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-					"dev": true
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
 				}
+			}
+		},
+		"rehype-parse": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-4.1.0.tgz",
+			"integrity": "sha512-EUg1mMY47O0wdRg65PzCdiAX5XFv/PFf/ss6+o6DclObM+iU0DklEZpUr3i2whVj8tV15q1kumnjgWcOnSkFDQ==",
+			"requires": {
+				"hast-util-from-parse5": "^2.0.1",
+				"parse5": "^4.0.0",
+				"xtend": "^4.0.1"
+			}
+		},
+		"rehype-raw": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-2.0.0.tgz",
+			"integrity": "sha1-Vjep/O7zSAD9fFfKMv2dWSf9Kqo=",
+			"requires": {
+				"hast-util-raw": "^2.0.0"
+			}
+		},
+		"remark-parse": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
+			"integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
+			"requires": {
+				"collapse-white-space": "^1.0.2",
+				"is-alphabetical": "^1.0.0",
+				"is-decimal": "^1.0.0",
+				"is-whitespace-character": "^1.0.0",
+				"is-word-character": "^1.0.0",
+				"markdown-escapes": "^1.0.0",
+				"parse-entities": "^1.1.0",
+				"repeat-string": "^1.5.4",
+				"state-toggle": "^1.0.0",
+				"trim": "0.0.1",
+				"trim-trailing-lines": "^1.0.0",
+				"unherit": "^1.0.4",
+				"unist-util-remove-position": "^1.0.0",
+				"vfile-location": "^2.0.0",
+				"xtend": "^4.0.1"
+			}
+		},
+		"remark-rehype": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-3.0.0.tgz",
+			"integrity": "sha512-WUinfb6vi34f4VYs2XS4HvuYNd0tCu68HOlG4aMp1dfFyVuVfL3aiL9WPw+Q6W99xTTHyxwr7BGO94jF0psoEA==",
+			"requires": {
+				"mdast-util-to-hast": "^3.0.0"
 			}
 		},
 		"remove-trailing-separator": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
-			"integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
-			"dev": true
+			"integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE="
 		},
 		"repeat-element": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-			"dev": true
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-			"dev": true
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
 		},
 		"repeating": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-			"dev": true,
 			"requires": {
 				"is-finite": "^1.0.0"
 			}
+		},
+		"replace-ext": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
 		},
 		"request": {
 			"version": "2.85.0",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
 			"integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
-			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
 				"aws4": "^1.6.0",
@@ -12417,14 +11660,12 @@
 				"mime-db": {
 					"version": "1.33.0",
 					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-					"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
-					"dev": true
+					"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
 				},
 				"mime-types": {
 					"version": "2.1.18",
 					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
 					"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-					"dev": true,
 					"requires": {
 						"mime-db": "~1.33.0"
 					}
@@ -12432,8 +11673,7 @@
 				"qs": {
 					"version": "6.5.1",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-					"dev": true
+					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
 				}
 			}
 		},
@@ -12441,7 +11681,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
 			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
-			"dev": true,
 			"requires": {
 				"lodash": "^4.13.1"
 			}
@@ -12450,7 +11689,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
 			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
-			"dev": true,
 			"requires": {
 				"request-promise-core": "1.1.1",
 				"stealthy-require": "^1.1.0",
@@ -12461,7 +11699,6 @@
 					"version": "2.3.4",
 					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
 					"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-					"dev": true,
 					"requires": {
 						"punycode": "^1.4.1"
 					}
@@ -12471,26 +11708,22 @@
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-			"dev": true
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
 		},
 		"require-from-string": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"dev": true
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
 		},
 		"require-main-filename": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-			"dev": true
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
 		"require-uncached": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-			"dev": true,
 			"requires": {
 				"caller-path": "^0.1.0",
 				"resolve-from": "^1.0.0"
@@ -12499,14 +11732,12 @@
 		"requires-port": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-			"dev": true
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
 		},
 		"resolve": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
 			"integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
-			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.5"
 			}
@@ -12515,7 +11746,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
-			"dev": true,
 			"requires": {
 				"resolve-from": "^3.0.0"
 			},
@@ -12523,28 +11753,24 @@
 				"resolve-from": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-					"dev": true
+					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
 				}
 			}
 		},
 		"resolve-from": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-			"dev": true
+			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
 		},
 		"resolve-url": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-			"dev": true
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
 		},
 		"restore-cursor": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-			"dev": true,
 			"requires": {
 				"onetime": "^2.0.0",
 				"signal-exit": "^3.0.2"
@@ -12553,14 +11779,12 @@
 		"ret": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-			"dev": true
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
 		},
 		"right-align": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
 			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-			"dev": true,
 			"requires": {
 				"align-text": "^0.1.1"
 			}
@@ -12569,7 +11793,6 @@
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
 			"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-			"dev": true,
 			"requires": {
 				"glob": "^7.0.5"
 			}
@@ -12578,7 +11801,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
 			"integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
-			"dev": true,
 			"requires": {
 				"hash-base": "^2.0.0",
 				"inherits": "^2.0.1"
@@ -12587,14 +11809,12 @@
 		"rsvp": {
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-			"integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-			"dev": true
+			"integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
 		},
 		"run-async": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-			"dev": true,
 			"requires": {
 				"is-promise": "^2.1.0"
 			}
@@ -12602,14 +11822,12 @@
 		"rx-lite": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-			"dev": true
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
 		},
 		"rx-lite-aggregates": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-			"dev": true,
 			"requires": {
 				"rx-lite": "*"
 			}
@@ -12618,7 +11836,6 @@
 			"version": "5.5.8",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.8.tgz",
 			"integrity": "sha512-Bz7qou7VAIoGiglJZbzbXa4vpX5BmTTN2Dj/se6+SwADtw4SihqBIiEa7VmTXJ8pynvq0iFr5Gx9VLyye1rIxQ==",
-			"dev": true,
 			"requires": {
 				"symbol-observable": "1.0.1"
 			},
@@ -12626,22 +11843,19 @@
 				"symbol-observable": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-					"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
-					"dev": true
+					"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
 				}
 			}
 		},
 		"safe-buffer": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-			"dev": true
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
 		},
 		"safe-regex": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-			"dev": true,
 			"requires": {
 				"ret": "~0.1.10"
 			}
@@ -12650,7 +11864,6 @@
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
 			"integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
-			"dev": true,
 			"requires": {
 				"anymatch": "^2.0.0",
 				"capture-exit": "^1.2.0",
@@ -12667,7 +11880,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
 					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-					"dev": true,
 					"requires": {
 						"micromatch": "^3.1.4",
 						"normalize-path": "^2.1.1"
@@ -12676,20 +11888,17 @@
 				"arr-diff": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
 				},
 				"array-unique": {
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 				},
 				"braces": {
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"dev": true,
 					"requires": {
 						"arr-flatten": "^1.1.0",
 						"array-unique": "^0.3.2",
@@ -12707,7 +11916,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -12718,7 +11926,6 @@
 					"version": "2.1.4",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"dev": true,
 					"requires": {
 						"debug": "^2.3.3",
 						"define-property": "^0.2.5",
@@ -12733,7 +11940,6 @@
 							"version": "0.2.5",
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
@@ -12742,7 +11948,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -12751,7 +11956,6 @@
 							"version": "0.1.6",
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^0.1.6",
 								"is-data-descriptor": "^0.1.4",
@@ -12761,8 +11965,7 @@
 						"kind-of": {
 							"version": "5.1.0",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-							"dev": true
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 						}
 					}
 				},
@@ -12770,7 +11973,6 @@
 					"version": "2.0.4",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"dev": true,
 					"requires": {
 						"array-unique": "^0.3.2",
 						"define-property": "^1.0.0",
@@ -12786,7 +11988,6 @@
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
 							"requires": {
 								"is-descriptor": "^1.0.0"
 							}
@@ -12795,7 +11996,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -12806,7 +12006,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"dev": true,
 					"requires": {
 						"extend-shallow": "^2.0.1",
 						"is-number": "^3.0.0",
@@ -12818,7 +12017,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -12829,7 +12027,6 @@
 					"version": "1.2.4",
 					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
 					"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"nan": "^2.9.2",
@@ -12839,24 +12036,20 @@
 						"abbrev": {
 							"version": "1.1.1",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"aproba": {
 							"version": "1.2.0",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						},
 						"are-we-there-yet": {
 							"version": "1.1.4",
 							"bundled": true,
-							"dev": true,
 							"optional": true,
 							"requires": {
 								"delegates": "^1.0.0",
@@ -12865,13 +12058,11 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -12880,34 +12071,28 @@
 						"chownr": {
 							"version": "1.0.1",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						},
 						"debug": {
 							"version": "2.6.9",
 							"bundled": true,
-							"dev": true,
 							"optional": true,
 							"requires": {
 								"ms": "2.0.0"
@@ -12916,25 +12101,21 @@
 						"deep-extend": {
 							"version": "0.5.1",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						},
 						"delegates": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						},
 						"detect-libc": {
 							"version": "1.0.3",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						},
 						"fs-minipass": {
 							"version": "1.2.5",
 							"bundled": true,
-							"dev": true,
 							"optional": true,
 							"requires": {
 								"minipass": "^2.2.1"
@@ -12943,13 +12124,11 @@
 						"fs.realpath": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						},
 						"gauge": {
 							"version": "2.7.4",
 							"bundled": true,
-							"dev": true,
 							"optional": true,
 							"requires": {
 								"aproba": "^1.0.3",
@@ -12965,7 +12144,6 @@
 						"glob": {
 							"version": "7.1.2",
 							"bundled": true,
-							"dev": true,
 							"optional": true,
 							"requires": {
 								"fs.realpath": "^1.0.0",
@@ -12979,13 +12157,11 @@
 						"has-unicode": {
 							"version": "2.0.1",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						},
 						"iconv-lite": {
 							"version": "0.4.21",
 							"bundled": true,
-							"dev": true,
 							"optional": true,
 							"requires": {
 								"safer-buffer": "^2.1.0"
@@ -12994,7 +12170,6 @@
 						"ignore-walk": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
 							"optional": true,
 							"requires": {
 								"minimatch": "^3.0.4"
@@ -13003,7 +12178,6 @@
 						"inflight": {
 							"version": "1.0.6",
 							"bundled": true,
-							"dev": true,
 							"optional": true,
 							"requires": {
 								"once": "^1.3.0",
@@ -13012,19 +12186,16 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"ini": {
 							"version": "1.3.5",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -13032,26 +12203,22 @@
 						"isarray": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						},
 						"minimatch": {
 							"version": "3.0.4",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"minipass": {
 							"version": "2.2.4",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"safe-buffer": "^5.1.1",
 								"yallist": "^3.0.0"
@@ -13060,7 +12227,6 @@
 						"minizlib": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true,
 							"optional": true,
 							"requires": {
 								"minipass": "^2.2.1"
@@ -13069,7 +12235,6 @@
 						"mkdirp": {
 							"version": "0.5.1",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
@@ -13077,13 +12242,11 @@
 						"ms": {
 							"version": "2.0.0",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						},
 						"needle": {
 							"version": "2.2.0",
 							"bundled": true,
-							"dev": true,
 							"optional": true,
 							"requires": {
 								"debug": "^2.1.2",
@@ -13094,7 +12257,6 @@
 						"node-pre-gyp": {
 							"version": "0.10.0",
 							"bundled": true,
-							"dev": true,
 							"optional": true,
 							"requires": {
 								"detect-libc": "^1.0.2",
@@ -13112,7 +12274,6 @@
 						"nopt": {
 							"version": "4.0.1",
 							"bundled": true,
-							"dev": true,
 							"optional": true,
 							"requires": {
 								"abbrev": "1",
@@ -13122,13 +12283,11 @@
 						"npm-bundled": {
 							"version": "1.0.3",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						},
 						"npm-packlist": {
 							"version": "1.1.10",
 							"bundled": true,
-							"dev": true,
 							"optional": true,
 							"requires": {
 								"ignore-walk": "^3.0.1",
@@ -13138,7 +12297,6 @@
 						"npmlog": {
 							"version": "4.1.2",
 							"bundled": true,
-							"dev": true,
 							"optional": true,
 							"requires": {
 								"are-we-there-yet": "~1.1.2",
@@ -13149,19 +12307,16 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						},
 						"once": {
 							"version": "1.4.0",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -13169,19 +12324,16 @@
 						"os-homedir": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						},
 						"os-tmpdir": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						},
 						"osenv": {
 							"version": "0.1.5",
 							"bundled": true,
-							"dev": true,
 							"optional": true,
 							"requires": {
 								"os-homedir": "^1.0.0",
@@ -13191,19 +12343,16 @@
 						"path-is-absolute": {
 							"version": "1.0.1",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						},
 						"process-nextick-args": {
 							"version": "2.0.0",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						},
 						"rc": {
 							"version": "1.2.7",
 							"bundled": true,
-							"dev": true,
 							"optional": true,
 							"requires": {
 								"deep-extend": "^0.5.1",
@@ -13215,7 +12364,6 @@
 								"minimist": {
 									"version": "1.2.0",
 									"bundled": true,
-									"dev": true,
 									"optional": true
 								}
 							}
@@ -13223,7 +12371,6 @@
 						"readable-stream": {
 							"version": "2.3.6",
 							"bundled": true,
-							"dev": true,
 							"optional": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -13238,7 +12385,6 @@
 						"rimraf": {
 							"version": "2.6.2",
 							"bundled": true,
-							"dev": true,
 							"optional": true,
 							"requires": {
 								"glob": "^7.0.5"
@@ -13246,43 +12392,36 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.1",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						},
 						"sax": {
 							"version": "1.2.4",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						},
 						"semver": {
 							"version": "5.5.0",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						},
 						"set-blocking": {
 							"version": "2.0.0",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						},
 						"signal-exit": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						},
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -13292,7 +12431,6 @@
 						"string_decoder": {
 							"version": "1.1.1",
 							"bundled": true,
-							"dev": true,
 							"optional": true,
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -13301,7 +12439,6 @@
 						"strip-ansi": {
 							"version": "3.0.1",
 							"bundled": true,
-							"dev": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -13309,13 +12446,11 @@
 						"strip-json-comments": {
 							"version": "2.0.1",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						},
 						"tar": {
 							"version": "4.4.1",
 							"bundled": true,
-							"dev": true,
 							"optional": true,
 							"requires": {
 								"chownr": "^1.0.1",
@@ -13330,13 +12465,11 @@
 						"util-deprecate": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true,
 							"optional": true
 						},
 						"wide-align": {
 							"version": "1.1.2",
 							"bundled": true,
-							"dev": true,
 							"optional": true,
 							"requires": {
 								"string-width": "^1.0.2"
@@ -13344,13 +12477,11 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						},
 						"yallist": {
 							"version": "3.0.2",
-							"bundled": true,
-							"dev": true
+							"bundled": true
 						}
 					}
 				},
@@ -13358,7 +12489,6 @@
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
@@ -13367,7 +12497,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -13378,7 +12507,6 @@
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
@@ -13387,7 +12515,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -13398,7 +12525,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
@@ -13407,7 +12533,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -13417,20 +12542,17 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				},
 				"micromatch": {
 					"version": "3.1.10",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"dev": true,
 					"requires": {
 						"arr-diff": "^4.0.0",
 						"array-unique": "^0.3.2",
@@ -13450,21 +12572,18 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"nan": {
 					"version": "2.10.0",
 					"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
 					"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-					"dev": true,
 					"optional": true
 				},
 				"normalize-path": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-					"dev": true,
 					"requires": {
 						"remove-trailing-separator": "^1.0.1"
 					}
@@ -13474,20 +12593,17 @@
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-			"dev": true
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
 		"select-hose": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
-			"integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
-			"dev": true
+			"integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
 		},
 		"selfsigned": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.9.1.tgz",
 			"integrity": "sha1-zdpEktcNSGVw+HxlVGAjVY4d+lo=",
-			"dev": true,
 			"requires": {
 				"node-forge": "0.6.33"
 			}
@@ -13495,14 +12611,12 @@
 		"semver": {
 			"version": "5.4.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-			"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-			"dev": true
+			"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
 		},
 		"send": {
 			"version": "0.15.3",
 			"resolved": "https://registry.npmjs.org/send/-/send-0.15.3.tgz",
 			"integrity": "sha1-UBP5+ZAj31DRvZiSwZ4979HVMwk=",
-			"dev": true,
 			"requires": {
 				"debug": "2.6.7",
 				"depd": "~1.1.0",
@@ -13523,7 +12637,6 @@
 					"version": "2.6.7",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
 					"integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -13534,7 +12647,6 @@
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.0.tgz",
 			"integrity": "sha1-0rKA/FYNYW7oG0i/D6gqvtJIXOc=",
-			"dev": true,
 			"requires": {
 				"accepts": "~1.3.3",
 				"batch": "0.6.1",
@@ -13549,7 +12661,6 @@
 			"version": "1.12.3",
 			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz",
 			"integrity": "sha1-n0uhni8wMMVH+K+ZEHg47DjVseI=",
-			"dev": true,
 			"requires": {
 				"encodeurl": "~1.0.1",
 				"escape-html": "~1.0.3",
@@ -13560,20 +12671,17 @@
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-			"dev": true
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 		},
 		"set-immediate-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-			"dev": true
+			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
 		},
 		"set-value": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
 				"is-extendable": "^0.1.1",
@@ -13585,7 +12693,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -13595,20 +12702,17 @@
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-			"dev": true
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"setprototypeof": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-			"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
-			"dev": true
+			"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
 		},
 		"sha.js": {
 			"version": "2.4.8",
 			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
 			"integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1"
 			}
@@ -13617,7 +12721,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-			"dev": true,
 			"requires": {
 				"shebang-regex": "^1.0.0"
 			}
@@ -13625,32 +12728,32 @@
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-			"dev": true
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
 		},
 		"shellwords": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-			"dev": true
+			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
+		},
+		"sigmund": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
 		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-			"dev": true
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-			"dev": true
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
 		},
 		"slice-ansi": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
 			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0"
 			}
@@ -13659,7 +12762,6 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
-			"dev": true,
 			"requires": {
 				"base": "^0.11.1",
 				"debug": "^2.2.0",
@@ -13675,7 +12777,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -13684,7 +12785,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -13693,7 +12793,6 @@
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
@@ -13702,7 +12801,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -13713,7 +12811,6 @@
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
@@ -13722,7 +12819,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -13733,7 +12829,6 @@
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^0.1.6",
 						"is-data-descriptor": "^0.1.4",
@@ -13743,8 +12838,7 @@
 				"kind-of": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-					"dev": true
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 				}
 			}
 		},
@@ -13752,7 +12846,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-			"dev": true,
 			"requires": {
 				"define-property": "^1.0.0",
 				"isobject": "^3.0.0",
@@ -13763,7 +12856,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -13771,8 +12863,7 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
 		},
@@ -13780,7 +12871,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.2.0"
 			}
@@ -13789,7 +12879,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
 			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-			"dev": true,
 			"requires": {
 				"hoek": "4.x.x"
 			}
@@ -13798,7 +12887,6 @@
 			"version": "0.3.18",
 			"resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz",
 			"integrity": "sha1-2bKJMWyn33dZXvKZ4HXw+TfrQgc=",
-			"dev": true,
 			"requires": {
 				"faye-websocket": "^0.10.0",
 				"uuid": "^2.0.2"
@@ -13807,8 +12895,7 @@
 				"uuid": {
 					"version": "2.0.3",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-					"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-					"dev": true
+					"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
 				}
 			}
 		},
@@ -13816,7 +12903,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
 			"integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
-			"dev": true,
 			"requires": {
 				"debug": "^2.6.6",
 				"eventsource": "0.1.6",
@@ -13830,7 +12916,6 @@
 					"version": "0.11.1",
 					"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
 					"integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
-					"dev": true,
 					"requires": {
 						"websocket-driver": ">=0.5.1"
 					}
@@ -13841,7 +12926,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
 			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-			"dev": true,
 			"requires": {
 				"is-plain-obj": "^1.0.0"
 			}
@@ -13849,20 +12933,17 @@
 		"source-list-map": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
-			"integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
-			"dev": true
+			"integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A=="
 		},
 		"source-map": {
 			"version": "0.5.6",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-			"integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
-			"dev": true
+			"integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
 		},
 		"source-map-resolve": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
 			"integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
-			"dev": true,
 			"requires": {
 				"atob": "^2.0.0",
 				"decode-uri-component": "^0.2.0",
@@ -13875,7 +12956,6 @@
 			"version": "0.4.18",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
 			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-			"dev": true,
 			"requires": {
 				"source-map": "^0.5.6"
 			}
@@ -13883,14 +12963,20 @@
 		"source-map-url": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-			"dev": true
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+		},
+		"space-separated-tokens": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.2.tgz",
+			"integrity": "sha512-G3jprCEw+xFEs0ORweLmblJ3XLymGGr6hxZYTYZjIlvDti9vOBUjRQa1Rzjt012aRrocKstHwdNi+F7HguPsEA==",
+			"requires": {
+				"trim": "0.0.1"
+			}
 		},
 		"spdx-correct": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
 			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-			"dev": true,
 			"requires": {
 				"spdx-license-ids": "^1.0.2"
 			}
@@ -13898,20 +12984,17 @@
 		"spdx-expression-parse": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-			"dev": true
+			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
 		},
 		"spdx-license-ids": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-			"dev": true
+			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
 		},
 		"spdy": {
 			"version": "3.4.7",
 			"resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
 			"integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
-			"dev": true,
 			"requires": {
 				"debug": "^2.6.8",
 				"handle-thing": "^1.2.5",
@@ -13925,7 +13008,6 @@
 			"version": "2.0.20",
 			"resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.20.tgz",
 			"integrity": "sha1-c15yBUxIayNU/onnAiVgBKOazk0=",
-			"dev": true,
 			"requires": {
 				"debug": "^2.6.8",
 				"detect-node": "^2.0.3",
@@ -13940,7 +13022,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
 			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
 			"requires": {
 				"through": "2"
 			}
@@ -13949,7 +13030,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.0"
 			}
@@ -13958,7 +13038,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
 			"integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
-			"dev": true,
 			"requires": {
 				"through2": "^2.0.2"
 			}
@@ -13966,14 +13045,12 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {
 			"version": "1.13.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
 			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -13988,34 +13065,34 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-					"dev": true
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 				}
 			}
 		},
 		"stable": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.6.tgz",
-			"integrity": "sha1-kQ9dKu17Ugxud3SZwfMuE5/eyxA=",
-			"dev": true
+			"integrity": "sha1-kQ9dKu17Ugxud3SZwfMuE5/eyxA="
 		},
 		"stack-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
-			"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
-			"dev": true
+			"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA="
 		},
 		"staged-git-files": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-1.1.1.tgz",
-			"integrity": "sha512-H89UNKr1rQJvI1c/PIR3kiAMBV23yvR7LItZiV74HWZwzt7f3YHuujJ9nJZlt58WlFox7XQsOahexwk7nTe69A==",
-			"dev": true
+			"integrity": "sha512-H89UNKr1rQJvI1c/PIR3kiAMBV23yvR7LItZiV74HWZwzt7f3YHuujJ9nJZlt58WlFox7XQsOahexwk7nTe69A=="
+		},
+		"state-toggle": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.1.tgz",
+			"integrity": "sha512-Qe8QntFrrpWTnHwvwj2FZTgv+PKIsp0B9VxLzLLbSpPXWOgRgc5LVj/aTiSfK1RqIeF9jeC1UeOH8Q8y60A7og=="
 		},
 		"static-extend": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-			"dev": true,
 			"requires": {
 				"define-property": "^0.2.5",
 				"object-copy": "^0.1.0"
@@ -14025,7 +13102,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -14034,7 +13110,6 @@
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
@@ -14043,7 +13118,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -14054,7 +13128,6 @@
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
@@ -14063,7 +13136,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -14074,7 +13146,6 @@
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^0.1.6",
 						"is-data-descriptor": "^0.1.4",
@@ -14084,28 +13155,24 @@
 				"kind-of": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-					"dev": true
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 				}
 			}
 		},
 		"statuses": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-			"integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-			"dev": true
+			"integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
 		},
 		"stealthy-require": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-			"dev": true
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
 		},
 		"stream-browserify": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
 			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
-			"dev": true,
 			"requires": {
 				"inherits": "~2.0.1",
 				"readable-stream": "^2.0.2"
@@ -14115,7 +13182,6 @@
 			"version": "2.7.2",
 			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
 			"integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
-			"dev": true,
 			"requires": {
 				"builtin-status-codes": "^3.0.0",
 				"inherits": "^2.0.1",
@@ -14128,7 +13194,6 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.2.0.tgz",
 			"integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
-			"dev": true,
 			"requires": {
 				"any-observable": "^0.2.0"
 			}
@@ -14136,14 +13201,12 @@
 		"string-argv": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.0.2.tgz",
-			"integrity": "sha1-2sMECGkMIfPDYwo/86BYd73L1zY=",
-			"dev": true
+			"integrity": "sha1-2sMECGkMIfPDYwo/86BYd73L1zY="
 		},
 		"string-length": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
 			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
-			"dev": true,
 			"requires": {
 				"astral-regex": "^1.0.0",
 				"strip-ansi": "^4.0.0"
@@ -14152,14 +13215,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -14170,7 +13231,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0",
 				"strip-ansi": "^4.0.0"
@@ -14179,14 +13239,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -14197,16 +13255,25 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
 			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
+			}
+		},
+		"stringify-entities": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
+			"integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
+			"requires": {
+				"character-entities-html4": "^1.0.0",
+				"character-entities-legacy": "^1.0.0",
+				"is-alphanumerical": "^1.0.0",
+				"is-hexadecimal": "^1.0.0"
 			}
 		},
 		"stringify-object": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.2.tgz",
 			"integrity": "sha512-O696NF21oLiDy8PhpWu8AEqoZHw++QW6mUv0UvKZe8gWSdSvMXkiLufK7OmnP27Dro4GU5kb9U7JIO0mBuCRQg==",
-			"dev": true,
 			"requires": {
 				"get-own-enumerable-property-symbols": "^2.0.1",
 				"is-obj": "^1.0.1",
@@ -14216,14 +13283,12 @@
 		"stringstream": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-			"dev": true
+			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			}
@@ -14232,7 +13297,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-			"dev": true,
 			"requires": {
 				"is-utf8": "^0.2.0"
 			}
@@ -14240,26 +13304,22 @@
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-			"dev": true
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 		},
 		"strip-indent": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-			"dev": true
+			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
 		},
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-			"dev": true
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 		},
 		"strong-log-transformer": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-1.0.6.tgz",
 			"integrity": "sha1-9/uTdYpppXEUAYEnfuoMLrEwH6M=",
-			"dev": true,
 			"requires": {
 				"byline": "^5.0.0",
 				"duplexer": "^0.1.1",
@@ -14271,22 +13331,19 @@
 				"minimist": {
 					"version": "0.1.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
-					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
-					"dev": true
+					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4="
 				}
 			}
 		},
 		"supports-color": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-			"dev": true
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 		},
 		"svgo": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.0.5.tgz",
 			"integrity": "sha512-nYrifviB77aNKDNKKyuay3M9aYiK6Hv5gJVDdjj2ZXTQmI8WZc8+UPLR5IpVlktJfSu3co/4XcWgrgI6seGBPg==",
-			"dev": true,
 			"requires": {
 				"coa": "~2.0.1",
 				"colors": "~1.1.2",
@@ -14308,7 +13365,6 @@
 					"version": "1.0.0-alpha25",
 					"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha25.tgz",
 					"integrity": "sha512-XC6xLW/JqIGirnZuUWHXCHRaAjje2b3OIB0Vj5RIJo6mIi/AdJo30quQl5LxUl0gkXDIrTrFGbMlcZjyFplz1A==",
-					"dev": true,
 					"requires": {
 						"mdn-data": "^1.0.0",
 						"source-map": "^0.5.3"
@@ -14318,7 +13374,6 @@
 					"version": "3.10.0",
 					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
 					"integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-					"dev": true,
 					"requires": {
 						"argparse": "^1.0.7",
 						"esprima": "^4.0.0"
@@ -14330,7 +13385,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/svgstore/-/svgstore-2.0.3.tgz",
 			"integrity": "sha512-K5GcfdH/lZbLyQv2Vi9pDAKUXBLZAn7eRoPGCzV+7gk7Fv/LOB1gLsNfevNSrcapX/q45M8x0XMct9ZjWRFImQ==",
-			"dev": true,
 			"requires": {
 				"cheerio": "^0.22.0",
 				"object-assign": "^4.1.0"
@@ -14339,20 +13393,17 @@
 		"symbol-observable": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
-			"integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
-			"dev": true
+			"integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A="
 		},
 		"symbol-tree": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
-			"dev": true
+			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
 		},
 		"table": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
 			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
-			"dev": true,
 			"requires": {
 				"ajv": "^5.2.3",
 				"ajv-keywords": "^2.1.0",
@@ -14366,7 +13417,6 @@
 					"version": "5.5.2",
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-					"dev": true,
 					"requires": {
 						"co": "^4.6.0",
 						"fast-deep-equal": "^1.0.0",
@@ -14378,7 +13428,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -14387,7 +13436,6 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
 					"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -14397,14 +13445,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"supports-color": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -14414,20 +13460,17 @@
 		"tapable": {
 			"version": "0.2.8",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
-			"integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
-			"dev": true
+			"integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
 		},
 		"temp-dir": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
-			"dev": true
+			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
 		},
 		"temp-write": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/temp-write/-/temp-write-3.4.0.tgz",
 			"integrity": "sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"is-stream": "^1.1.0",
@@ -14441,7 +13484,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
 			"integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
-			"dev": true,
 			"requires": {
 				"os-tmpdir": "^1.0.0",
 				"uuid": "^2.0.1"
@@ -14450,8 +13492,7 @@
 				"uuid": {
 					"version": "2.0.3",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-					"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-					"dev": true
+					"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
 				}
 			}
 		},
@@ -14459,7 +13500,6 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
 			"integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
-			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1",
 				"micromatch": "^3.1.8",
@@ -14471,20 +13511,17 @@
 				"arr-diff": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
 				},
 				"array-unique": {
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 				},
 				"braces": {
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"dev": true,
 					"requires": {
 						"arr-flatten": "^1.1.0",
 						"array-unique": "^0.3.2",
@@ -14502,7 +13539,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -14513,7 +13549,6 @@
 					"version": "2.1.4",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"dev": true,
 					"requires": {
 						"debug": "^2.3.3",
 						"define-property": "^0.2.5",
@@ -14528,7 +13563,6 @@
 							"version": "0.2.5",
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
@@ -14537,7 +13571,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -14546,7 +13579,6 @@
 							"version": "0.1.6",
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^0.1.6",
 								"is-data-descriptor": "^0.1.4",
@@ -14556,8 +13588,7 @@
 						"kind-of": {
 							"version": "5.1.0",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-							"dev": true
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 						}
 					}
 				},
@@ -14565,7 +13596,6 @@
 					"version": "2.0.4",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"dev": true,
 					"requires": {
 						"array-unique": "^0.3.2",
 						"define-property": "^1.0.0",
@@ -14581,7 +13611,6 @@
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
 							"requires": {
 								"is-descriptor": "^1.0.0"
 							}
@@ -14590,7 +13619,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -14601,7 +13629,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"dev": true,
 					"requires": {
 						"extend-shallow": "^2.0.1",
 						"is-number": "^3.0.0",
@@ -14613,7 +13640,6 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -14624,7 +13650,6 @@
 					"version": "0.1.6",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
@@ -14633,7 +13658,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -14644,7 +13668,6 @@
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
@@ -14653,7 +13676,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -14664,7 +13686,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
@@ -14673,7 +13694,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -14683,20 +13703,17 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				},
 				"micromatch": {
 					"version": "3.1.10",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"dev": true,
 					"requires": {
 						"arr-diff": "^4.0.0",
 						"array-unique": "^0.3.2",
@@ -14718,32 +13735,27 @@
 		"text-extensions": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.7.0.tgz",
-			"integrity": "sha512-AKXZeDq230UaSzaO5s3qQUZOaC7iKbzq0jOFL614R7d9R593HLqAOL0cYoqLdkNrjBSOdmoQI06yigq1TSBXAg==",
-			"dev": true
+			"integrity": "sha512-AKXZeDq230UaSzaO5s3qQUZOaC7iKbzq0jOFL614R7d9R593HLqAOL0cYoqLdkNrjBSOdmoQI06yigq1TSBXAg=="
 		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-			"dev": true
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
 		},
 		"throat": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
-			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
-			"dev": true
+			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
 		},
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-			"dev": true
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
 		"through2": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-			"dev": true,
 			"requires": {
 				"readable-stream": "^2.1.5",
 				"xtend": "~4.0.1"
@@ -14752,26 +13764,22 @@
 		"thunky": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz",
-			"integrity": "sha1-vzAUaCTituZ7Dy16Ssi+smkIaE4=",
-			"dev": true
+			"integrity": "sha1-vzAUaCTituZ7Dy16Ssi+smkIaE4="
 		},
 		"time-stamp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
-			"integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c=",
-			"dev": true
+			"integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c="
 		},
 		"timed-out": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-			"dev": true
+			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
 		},
 		"tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-			"dev": true,
 			"requires": {
 				"os-tmpdir": "~1.0.2"
 			}
@@ -14779,26 +13787,22 @@
 		"tmpl": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
-			"dev": true
+			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
 		},
 		"to-arraybuffer": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
-			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
-			"dev": true
+			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
 		},
 		"to-fast-properties": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-			"dev": true
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
 		},
 		"to-object-path": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			}
@@ -14807,7 +13811,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-			"dev": true,
 			"requires": {
 				"define-property": "^2.0.2",
 				"extend-shallow": "^3.0.2",
@@ -14819,7 +13822,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-			"dev": true,
 			"requires": {
 				"is-number": "^3.0.0",
 				"repeat-string": "^1.6.1"
@@ -14829,7 +13831,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
@@ -14840,7 +13841,6 @@
 			"version": "2.3.4",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
 			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-			"dev": true,
 			"requires": {
 				"punycode": "^1.4.1"
 			}
@@ -14849,7 +13849,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
 			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			},
@@ -14857,40 +13856,54 @@
 				"punycode": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
-					"dev": true
+					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
 				}
 			}
+		},
+		"trim": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+			"integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+		},
+		"trim-lines": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.1.tgz",
+			"integrity": "sha512-X+eloHbgJGxczUk1WSjIvn7aC9oN3jVE3rQfRVKcgpavi3jxtCn0VVKtjOBj64Yop96UYn/ujJRpTbCdAF1vyg=="
 		},
 		"trim-newlines": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-			"dev": true
+			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
 		},
 		"trim-off-newlines": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
-			"dev": true
+			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM="
 		},
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-			"dev": true
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+		},
+		"trim-trailing-lines": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz",
+			"integrity": "sha512-bWLv9BbWbbd7mlqqs2oQYnLD/U/ZqeJeJwbO0FG2zA1aTq+HTvxfHNKFa/HGCVyJpDiioUYaBhfiT6rgk+l4mg=="
+		},
+		"trough": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.2.tgz",
+			"integrity": "sha512-FHkoUZvG6Egrv9XZAyYGKEyb1JMsFphgPjoczkZC2y6W93U1jswcVURB8MUvtsahEPEVACyxD47JAL63vF4JsQ=="
 		},
 		"tty-browserify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
-			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
-			"dev": true
+			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -14899,14 +13912,12 @@
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"dev": true,
 			"optional": true
 		},
 		"type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-			"dev": true,
 			"requires": {
 				"prelude-ls": "~1.1.2"
 			}
@@ -14915,7 +13926,6 @@
 			"version": "1.6.15",
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
 			"integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
-			"dev": true,
 			"requires": {
 				"media-typer": "0.3.0",
 				"mime-types": "~2.1.15"
@@ -14924,14 +13934,17 @@
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-			"dev": true
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+		},
+		"ua-parser-js": {
+			"version": "0.7.18",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
+			"integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
 		},
 		"uglify-js": {
 			"version": "2.8.29",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
 			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-			"dev": true,
 			"requires": {
 				"source-map": "~0.5.1",
 				"uglify-to-browserify": "~1.0.0",
@@ -14942,7 +13955,6 @@
 					"version": "3.10.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
 					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^1.0.2",
 						"cliui": "^2.1.0",
@@ -14956,25 +13968,44 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
 			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-			"dev": true,
 			"optional": true
 		},
 		"uglifyjs-webpack-plugin": {
 			"version": "0.4.6",
 			"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
 			"integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
-			"dev": true,
 			"requires": {
 				"source-map": "^0.5.6",
 				"uglify-js": "^2.8.29",
 				"webpack-sources": "^1.0.1"
 			}
 		},
+		"unherit": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
+			"integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
+			"requires": {
+				"inherits": "^2.0.1",
+				"xtend": "^4.0.1"
+			}
+		},
+		"unified": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
+			"integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
+			"requires": {
+				"bail": "^1.0.0",
+				"extend": "^3.0.0",
+				"is-plain-obj": "^1.1.0",
+				"trough": "^1.0.0",
+				"vfile": "^2.0.0",
+				"x-is-string": "^0.1.0"
+			}
+		},
 		"union-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
-			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"get-value": "^2.0.6",
@@ -14986,7 +14017,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -14995,7 +14025,6 @@
 					"version": "0.4.3",
 					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-					"dev": true,
 					"requires": {
 						"extend-shallow": "^2.0.1",
 						"is-extendable": "^0.1.1",
@@ -15005,29 +14034,69 @@
 				}
 			}
 		},
+		"unist-builder": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.2.tgz",
+			"integrity": "sha1-jDuZA+9kvPsRfdfPal2Y/Bs7J7Y=",
+			"requires": {
+				"object-assign": "^4.1.0"
+			}
+		},
+		"unist-util-generated": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.2.tgz",
+			"integrity": "sha512-1HcwiEO62dr0XWGT+abVK4f0aAm8Ik8N08c5nAYVmuSxfvpA9rCcNyX/le8xXj1pJK5nBrGlZefeWB6bN8Pstw=="
+		},
+		"unist-util-is": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.2.tgz",
+			"integrity": "sha512-YkXBK/H9raAmG7KXck+UUpnKiNmUdB+aBGrknfQ4EreE1banuzrKABx3jP6Z5Z3fMSPMQQmeXBlKpCbMwBkxVw=="
+		},
+		"unist-util-position": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.0.1.tgz",
+			"integrity": "sha512-05QfJDPI7PE1BIUtAxeSV+cDx21xP7+tUZgSval5CA7tr0pHBwybF7OnEa1dOFqg6BfYH/qiMUnWwWj+Frhlww=="
+		},
+		"unist-util-remove-position": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz",
+			"integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
+			"requires": {
+				"unist-util-visit": "^1.1.0"
+			}
+		},
+		"unist-util-stringify-position": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+			"integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+		},
+		"unist-util-visit": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.3.1.tgz",
+			"integrity": "sha512-0fdB9EQJU0tho5tK0VzOJzAQpPv2LyLZ030b10GxuzAWEfvd54mpY7BMjQ1L69k2YNvL+SvxRzH0yUIehOO8aA==",
+			"requires": {
+				"unist-util-is": "^2.1.1"
+			}
+		},
 		"universalify": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-			"integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
-			"dev": true
+			"integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
 		},
 		"unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-			"dev": true
+			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
 		},
 		"unquote": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
-			"integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
-			"dev": true
+			"integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
 		},
 		"unset-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-			"dev": true,
 			"requires": {
 				"has-value": "^0.3.1",
 				"isobject": "^3.0.0"
@@ -15037,7 +14106,6 @@
 					"version": "0.3.1",
 					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-					"dev": true,
 					"requires": {
 						"get-value": "^2.0.3",
 						"has-values": "^0.1.4",
@@ -15048,7 +14116,6 @@
 							"version": "2.1.0",
 							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-							"dev": true,
 							"requires": {
 								"isarray": "1.0.0"
 							}
@@ -15058,34 +14125,42 @@
 				"has-values": {
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-					"dev": true
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
 				},
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
 		},
 		"unzip-response": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-			"dev": true
+			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
+		},
+		"upper-case": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+			"integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
+		},
+		"upper-case-first": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
+			"integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
+			"requires": {
+				"upper-case": "^1.1.1"
+			}
 		},
 		"urix": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-			"dev": true
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
 		},
 		"url": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
 			"integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-			"dev": true,
 			"requires": {
 				"punycode": "1.3.2",
 				"querystring": "0.2.0"
@@ -15094,8 +14169,7 @@
 				"punycode": {
 					"version": "1.3.2",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-					"dev": true
+					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
 				}
 			}
 		},
@@ -15103,7 +14177,6 @@
 			"version": "1.1.9",
 			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
 			"integrity": "sha1-xn8dd11R8KGJEd17P/rSe7nlvRk=",
-			"dev": true,
 			"requires": {
 				"querystringify": "~1.0.0",
 				"requires-port": "1.0.x"
@@ -15112,8 +14185,7 @@
 				"querystringify": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
-					"integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs=",
-					"dev": true
+					"integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs="
 				}
 			}
 		},
@@ -15121,7 +14193,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
 			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-			"dev": true,
 			"requires": {
 				"prepend-http": "^1.0.1"
 			}
@@ -15130,7 +14201,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
 			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
-			"dev": true,
 			"requires": {
 				"kind-of": "^6.0.2"
 			},
@@ -15138,8 +14208,7 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"dev": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
@@ -15147,7 +14216,6 @@
 			"version": "0.10.3",
 			"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
 			"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-			"dev": true,
 			"requires": {
 				"inherits": "2.0.1"
 			},
@@ -15155,22 +14223,19 @@
 				"inherits": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-					"dev": true
+					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
 				}
 			}
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"util.promisify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
 			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"object.getownpropertydescriptors": "^2.0.3"
@@ -15179,20 +14244,17 @@
 		"utils-merge": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-			"integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
-			"dev": true
+			"integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
 		},
 		"uuid": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-			"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-			"dev": true
+			"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
 			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-			"dev": true,
 			"requires": {
 				"spdx-correct": "~1.0.0",
 				"spdx-expression-parse": "~1.0.0"
@@ -15201,14 +14263,12 @@
 		"vary": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
-			"integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc=",
-			"dev": true
+			"integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc="
 		},
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
@@ -15218,22 +14278,43 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-					"dev": true
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 				}
+			}
+		},
+		"vfile": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
+			"integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
+			"requires": {
+				"is-buffer": "^1.1.4",
+				"replace-ext": "1.0.0",
+				"unist-util-stringify-position": "^1.0.0",
+				"vfile-message": "^1.0.0"
+			}
+		},
+		"vfile-location": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.3.tgz",
+			"integrity": "sha512-zM5/l4lfw1CBoPx3Jimxoc5RNDAHHpk6AM6LM0pTIkm5SUSsx8ZekZ0PVdf0WEZ7kjlhSt7ZlqbRL6Cd6dBs6A=="
+		},
+		"vfile-message": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.0.1.tgz",
+			"integrity": "sha512-vSGCkhNvJzO6VcWC6AlJW4NtYOVtS+RgCaqFIYUjoGIlHnFL+i0LbtYvonDWOMcB97uTPT4PRsyYY7REWC9vug==",
+			"requires": {
+				"unist-util-stringify-position": "^1.1.1"
 			}
 		},
 		"vlq": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
-			"integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
-			"dev": true
+			"integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="
 		},
 		"vm-browserify": {
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
 			"integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-			"dev": true,
 			"requires": {
 				"indexof": "0.0.1"
 			}
@@ -15242,7 +14323,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
 			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
-			"dev": true,
 			"requires": {
 				"browser-process-hrtime": "^0.1.2"
 			}
@@ -15251,7 +14331,6 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
 			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
-			"dev": true,
 			"requires": {
 				"makeerror": "1.0.x"
 			}
@@ -15260,7 +14339,6 @@
 			"version": "0.18.0",
 			"resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
 			"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
-			"dev": true,
 			"requires": {
 				"exec-sh": "^0.2.0",
 				"minimist": "^1.2.0"
@@ -15269,8 +14347,7 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
 		},
@@ -15278,7 +14355,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
 			"integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
-			"dev": true,
 			"requires": {
 				"async": "^2.1.2",
 				"chokidar": "^1.7.0",
@@ -15289,7 +14365,6 @@
 			"version": "1.7.2",
 			"resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz",
 			"integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
-			"dev": true,
 			"requires": {
 				"minimalistic-assert": "^1.0.0"
 			}
@@ -15298,22 +14373,24 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
 			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
-			"dev": true,
 			"requires": {
 				"defaults": "^1.0.3"
 			}
 		},
+		"web-namespaces": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.2.tgz",
+			"integrity": "sha512-II+n2ms4mPxK+RnIxRPOw3zwF2jRscdJIUE9BfkKHm4FYEg9+biIoTMnaZF5MpemE3T+VhMLrhbyD4ilkPCSbg=="
+		},
 		"webidl-conversions": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-			"dev": true
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
 		},
 		"webpack": {
 			"version": "3.4.1",
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.4.1.tgz",
 			"integrity": "sha1-TD9PP7MYFVpNsMtqNv8FxWl0GPQ=",
-			"dev": true,
 			"requires": {
 				"acorn": "^5.0.0",
 				"acorn-dynamic-import": "^2.0.0",
@@ -15342,20 +14419,17 @@
 				"ajv-keywords": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
-					"integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
-					"dev": true
+					"integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA="
 				},
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"cliui": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
 						"strip-ansi": "^3.0.1",
@@ -15366,7 +14440,6 @@
 							"version": "1.0.2",
 							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -15379,7 +14452,6 @@
 					"version": "0.7.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
 						"get-stream": "^3.0.0",
@@ -15394,7 +14466,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -15403,7 +14474,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
 					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^2.2.0",
@@ -15414,8 +14484,7 @@
 						"pify": {
 							"version": "2.3.0",
 							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-							"dev": true
+							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 						}
 					}
 				},
@@ -15423,7 +14492,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
 					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-					"dev": true,
 					"requires": {
 						"execa": "^0.7.0",
 						"lcid": "^1.0.0",
@@ -15434,7 +14502,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
 					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-					"dev": true,
 					"requires": {
 						"pify": "^2.0.0"
 					},
@@ -15442,8 +14509,7 @@
 						"pify": {
 							"version": "2.3.0",
 							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-							"dev": true
+							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 						}
 					}
 				},
@@ -15451,7 +14517,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
 					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^2.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -15462,7 +14527,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
 					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^2.0.0"
@@ -15471,14 +14535,12 @@
 				"strip-bom": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-					"dev": true
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 				},
 				"supports-color": {
 					"version": "4.2.1",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
 					"integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^2.0.0"
 					}
@@ -15486,14 +14548,12 @@
 				"which-module": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-					"dev": true
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 				},
 				"yargs": {
 					"version": "8.0.2",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
 					"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0",
 						"cliui": "^3.2.0",
@@ -15514,7 +14574,6 @@
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
 					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0"
 					}
@@ -15525,7 +14584,6 @@
 			"version": "1.12.0",
 			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.0.tgz",
 			"integrity": "sha1-007++y7dp+HTtdvgcolRMhllFwk=",
-			"dev": true,
 			"requires": {
 				"memory-fs": "~0.4.1",
 				"mime": "^1.3.4",
@@ -15538,7 +14596,6 @@
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.6.1.tgz",
 			"integrity": "sha1-Cykqnaltr4CmWYj2n4e0Fm5d7+c=",
-			"dev": true,
 			"requires": {
 				"ansi-html": "0.0.7",
 				"bonjour": "^3.5.0",
@@ -15567,14 +14624,12 @@
 				"camelcase": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-					"dev": true
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
 				},
 				"cliui": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
 						"strip-ansi": "^3.0.1",
@@ -15584,14 +14639,12 @@
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-					"dev": true
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -15600,7 +14653,6 @@
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
 					"integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
-					"dev": true,
 					"requires": {
 						"object-assign": "^4.0.1",
 						"pinkie-promise": "^2.0.0"
@@ -15610,7 +14662,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -15621,7 +14672,6 @@
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"dev": true,
 					"requires": {
 						"has-flag": "^1.0.0"
 					}
@@ -15630,7 +14680,6 @@
 					"version": "6.6.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
 					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^3.0.0",
 						"cliui": "^3.2.0",
@@ -15651,7 +14700,6 @@
 					"version": "4.2.1",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
 					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^3.0.0"
 					}
@@ -15662,7 +14710,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/webpack-parallel-uglify-plugin/-/webpack-parallel-uglify-plugin-1.1.0.tgz",
 			"integrity": "sha512-HgNqQrXuCvV+S5qCgv9vrJfcldmxQ57KYZNMXVk842XFzunXQm/GbSM/Pwli7taOeiEX8ypFpSTGyMBRKc++rg==",
-			"dev": true,
 			"requires": {
 				"babel-code-frame": "^6.26.0",
 				"glob": "^7.0.5",
@@ -15678,20 +14725,17 @@
 				"commander": {
 					"version": "2.13.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
-					"dev": true
+					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"tmp": {
 					"version": "0.0.29",
 					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
 					"integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
-					"dev": true,
 					"requires": {
 						"os-tmpdir": "~1.0.1"
 					}
@@ -15700,7 +14744,6 @@
 					"version": "3.3.9",
 					"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
 					"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-					"dev": true,
 					"requires": {
 						"commander": "~2.13.0",
 						"source-map": "~0.6.1"
@@ -15710,7 +14753,6 @@
 					"version": "3.3.16",
 					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.16.tgz",
 					"integrity": "sha512-FMh5SRqJRGhv9BbaTffENIpDDQIoPDR8DBraunGORGhySArsXlw9++CN+BWzPBLpoI4RcSnpfGPnilTxWL3Vvg==",
-					"dev": true,
 					"requires": {
 						"commander": "~2.15.0",
 						"source-map": "~0.6.1"
@@ -15719,8 +14761,7 @@
 						"commander": {
 							"version": "2.15.1",
 							"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-							"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-							"dev": true
+							"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
 						}
 					}
 				}
@@ -15730,7 +14771,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
 			"integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
-			"dev": true,
 			"requires": {
 				"source-list-map": "^2.0.0",
 				"source-map": "~0.5.3"
@@ -15740,7 +14780,6 @@
 			"version": "0.6.5",
 			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
 			"integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
-			"dev": true,
 			"requires": {
 				"websocket-extensions": ">=0.1.1"
 			}
@@ -15748,23 +14787,25 @@
 		"websocket-extensions": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
-			"integrity": "sha1-domUmcGEtu91Q3fC27DNbLVdKec=",
-			"dev": true
+			"integrity": "sha1-domUmcGEtu91Q3fC27DNbLVdKec="
 		},
 		"whatwg-encoding": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
 			"integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
-			"dev": true,
 			"requires": {
 				"iconv-lite": "0.4.19"
 			}
+		},
+		"whatwg-fetch": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
 		},
 		"whatwg-url": {
 			"version": "6.4.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
 			"integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
-			"dev": true,
 			"requires": {
 				"lodash.sortby": "^4.7.0",
 				"tr46": "^1.0.0",
@@ -15775,7 +14816,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
 			}
@@ -15783,14 +14823,12 @@
 		"which-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-			"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-			"dev": true
+			"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
 		},
 		"wide-align": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
 			"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-			"dev": true,
 			"requires": {
 				"string-width": "^1.0.2"
 			},
@@ -15799,7 +14837,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -15808,7 +14845,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -15820,20 +14856,17 @@
 		"window-size": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-			"dev": true
+			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
 		},
 		"wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-			"dev": true
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
 		},
 		"worker-farm": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.4.1.tgz",
 			"integrity": "sha512-tgFAtgOYLPutkAyzgpS6VJFL5HY+0ui1Tvua+fITgz8ByaJTMFGtazR6xxQfwfiAcbwE+2fLG/K49wc2TfwCNw==",
-			"dev": true,
 			"requires": {
 				"errno": "^0.1.4",
 				"xtend": "^4.0.1"
@@ -15843,7 +14876,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-			"dev": true,
 			"requires": {
 				"string-width": "^1.0.1",
 				"strip-ansi": "^3.0.1"
@@ -15853,7 +14885,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -15862,7 +14893,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -15874,14 +14904,12 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-			"dev": true,
 			"requires": {
 				"mkdirp": "^0.5.1"
 			}
@@ -15890,7 +14918,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.11",
 				"imurmurhash": "^0.1.4",
@@ -15901,7 +14928,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
 			"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
-			"dev": true,
 			"requires": {
 				"detect-indent": "^5.0.0",
 				"graceful-fs": "^4.1.2",
@@ -15914,8 +14940,7 @@
 				"detect-indent": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-					"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
-					"dev": true
+					"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
 				}
 			}
 		},
@@ -15923,7 +14948,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-3.1.0.tgz",
 			"integrity": "sha1-AwqZlMyZk9JbTnWp8aGSNgcpHOk=",
-			"dev": true,
 			"requires": {
 				"sort-keys": "^2.0.0",
 				"write-json-file": "^2.2.0"
@@ -15933,35 +14957,40 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
 			"integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
-			"dev": true,
 			"requires": {
 				"async-limiter": "~1.0.0",
 				"safe-buffer": "~5.1.0"
 			}
 		},
+		"x-is-array": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/x-is-array/-/x-is-array-0.1.0.tgz",
+			"integrity": "sha1-3lIBcdR7P0FvVYfWKbidJrEtwp0="
+		},
+		"x-is-string": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+			"integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
+		},
 		"xtend": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-			"dev": true
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
 		},
 		"y18n": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-			"dev": true
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
 		},
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-			"dev": true
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 		},
 		"yargs": {
 			"version": "4.8.1",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
 			"integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
-			"dev": true,
 			"requires": {
 				"cliui": "^3.2.0",
 				"decamelize": "^1.1.1",
@@ -15983,7 +15012,6 @@
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
 						"strip-ansi": "^3.0.1",
@@ -15994,7 +15022,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -16003,7 +15030,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -16013,8 +15039,7 @@
 				"window-size": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-					"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
-					"dev": true
+					"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
 				}
 			}
 		},
@@ -16022,7 +15047,6 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
 			"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
-			"dev": true,
 			"requires": {
 				"camelcase": "^3.0.0",
 				"lodash.assign": "^4.0.6"
@@ -16031,10 +15055,14 @@
 				"camelcase": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-					"dev": true
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
 				}
 			}
+		},
+		"zwitch": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.3.tgz",
+			"integrity": "sha512-aynRpmJDw7JIq6X4NDWJoiK1yVSiG57ArWSg4HLC1SFupX5/bo0Cf4jpX0ifwuzBfxpYBuNSyvMlWNNRuy3cVA=="
 		}
 	}
 }

--- a/packages/babel-plugin-transform-jsxtreme-markdown/README.md
+++ b/packages/babel-plugin-transform-jsxtreme-markdown/README.md
@@ -16,14 +16,14 @@ npm install @mapbox/babel-plugin-transform-jsxtreme-markdown
 
 Transforms a special [tagged template literal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_template_literals).
 
-`require` or `import` the (fake) package `'babel-plugin-transform-jsxtreme-markdown/md'`, or whatever you've specified as `packageName` in your Babel options.
+`require` or `import` the (fake) package `'@mapbox/babel-plugin-transform-jsxtreme-markdown/md'`, or whatever you've specified as `packageName` in your Babel options.
 Then use that (fake) module's export as a template literal tag, marking the template literals you'd like to be compiled at run time.
 
 If `React` is not already in the file's top-level scope, `var React = require('react');` will be added to the beginning of the file.
 
 ```jsx
 // Input
-const md = require('babel-plugin-transform-jsxtreme-markdown/md');
+const md = require('@mapbox/babel-plugin-transform-jsxtreme-markdown/md');
 const foo = md`
   # Title
   This is **bold.**
@@ -46,7 +46,7 @@ Read more about this in the jsxtreme-markdown docs.
 
 ```jsx
 // Input
-import md from 'babel-plugin-transform-jsxtreme-markdown/md';
+import md from '@mapbox/babel-plugin-transform-jsxtreme-markdown/md';
 const text = md`
   This is a paragraph {{<span className="foo">}} with a **markdown** span inside {{</span>}}
   {{ <div style={{ margin: 70 }}> }}
@@ -77,7 +77,7 @@ Additional options:
 #### packageName
 
 Type: `string`.
-Default: `'babel-plugin-transform-jsxtreme-markdown/md'`.
+Default: `'@mapbox/babel-plugin-transform-jsxtreme-markdown/md'`.
 
 The name of the package that you will `require` or `import` to use this thing.
 For example, with the value `'xtreme-markdown'` you should use

--- a/packages/babel-plugin-transform-jsxtreme-markdown/index.js
+++ b/packages/babel-plugin-transform-jsxtreme-markdown/index.js
@@ -10,4 +10,7 @@ const applyTransform = (templateExpressionPath, text, options) => {
   templateExpressionPath.replaceWith(ast);
 };
 
-module.exports = templateTagMacro('jsxtreme-markdown/md', applyTransform);
+module.exports = templateTagMacro(
+  'babel-plugin-transform-jsxtreme-markdown/md',
+  applyTransform
+);

--- a/packages/babel-plugin-transform-jsxtreme-markdown/index.js
+++ b/packages/babel-plugin-transform-jsxtreme-markdown/index.js
@@ -11,6 +11,6 @@ const applyTransform = (templateExpressionPath, text, options) => {
 };
 
 module.exports = templateTagMacro(
-  'babel-plugin-transform-jsxtreme-markdown/md',
+  '@mapbox/babel-plugin-transform-jsxtreme-markdown/md',
   applyTransform
 );

--- a/packages/babel-plugin-transform-jsxtreme-markdown/test/index.test.js
+++ b/packages/babel-plugin-transform-jsxtreme-markdown/test/index.test.js
@@ -13,7 +13,7 @@ const transform = (code, options) => {
 
 test('basic usage', () => {
   const code = `
-    const md = require('babel-plugin-transform-jsxtreme-markdown/md');
+    const md = require('@mapbox/babel-plugin-transform-jsxtreme-markdown/md');
     const foo = md\`
       # Title
       This is **bold.**
@@ -25,7 +25,7 @@ test('basic usage', () => {
 
 test('import instead of require', () => {
   const code = `
-    import md from 'babel-plugin-transform-jsxtreme-markdown/md';
+    import md from '@mapbox/babel-plugin-transform-jsxtreme-markdown/md';
     const foo = md\`
       # Title
       This is **bold.**
@@ -51,7 +51,7 @@ test('require in nested scope', () => {
   const code = `
     function x() {
       if (true) {
-        const md = require('babel-plugin-transform-jsxtreme-markdown/md');
+        const md = require('@mapbox/babel-plugin-transform-jsxtreme-markdown/md');
         const foo = md\`
           # Title
           This is **bold.**
@@ -65,7 +65,7 @@ test('require in nested scope', () => {
 
 test('alternate variable name, with broken-up nested JSX', () => {
   const code = `
-    const markit = require('babel-plugin-transform-jsxtreme-markdown/md');
+    const markit = require('@mapbox/babel-plugin-transform-jsxtreme-markdown/md');
     const text = markit\`
     This is a paragraph {{ <span className="foo"> }} with a **markdown** span inside {{ </span> }}
     {{ <div style={{ margin: 70 }}> }}
@@ -78,7 +78,7 @@ test('alternate variable name, with broken-up nested JSX', () => {
 
 test('toJsx options', () => {
   const code = `
-    import md from 'babel-plugin-transform-jsxtreme-markdown/md';
+    import md from '@mapbox/babel-plugin-transform-jsxtreme-markdown/md';
     const foo = md\`
       This is a paragraph {{ <span className="foo">with a span inside</span> }}
       {# <div style={{ margin: 70 }}> #}
@@ -95,7 +95,7 @@ test('toJsx options', () => {
 
 test('fails with placeholders in template literals', () => {
   const code = `
-    const md = require('babel-plugin-transform-jsxtreme-markdown/md');
+    const md = require('@mapbox/babel-plugin-transform-jsxtreme-markdown/md');
     const foo = md\`
       # Title
       This is **bold.** $\{number}
@@ -108,7 +108,7 @@ test('fails with placeholders in template literals', () => {
 test('does nothing when module is not in scope', () => {
   const code = `
     function x() {
-      const md = require('babel-plugin-transform-jsxtreme-markdown/md');
+      const md = require('@mapbox/babel-plugin-transform-jsxtreme-markdown/md');
     }
     const foo = md\`
       # Title
@@ -122,7 +122,7 @@ test('does nothing when module is not in scope', () => {
 test('does not add React to scope when it is already required', () => {
   const code = `
     const React = require('react');
-    const md = require('babel-plugin-transform-jsxtreme-markdown/md');
+    const md = require('@mapbox/babel-plugin-transform-jsxtreme-markdown/md');
     const foo = md\`
       # Title
       This is **bold.**
@@ -135,7 +135,7 @@ test('does not add React to scope when it is already required', () => {
 test('does not add React to scope when it is already imported', () => {
   const code = `
     import React from 'react';
-    import md from 'babel-plugin-transform-jsxtreme-markdown/md';
+    import md from '@mapbox/babel-plugin-transform-jsxtreme-markdown/md';
     const foo = md\`
       # Title
       This is **bold.**

--- a/packages/babel-plugin-transform-jsxtreme-markdown/test/index.test.js
+++ b/packages/babel-plugin-transform-jsxtreme-markdown/test/index.test.js
@@ -13,7 +13,7 @@ const transform = (code, options) => {
 
 test('basic usage', () => {
   const code = `
-    const md = require('jsxtreme-markdown/md');
+    const md = require('babel-plugin-transform-jsxtreme-markdown/md');
     const foo = md\`
       # Title
       This is **bold.**
@@ -25,7 +25,7 @@ test('basic usage', () => {
 
 test('import instead of require', () => {
   const code = `
-    import md from 'jsxtreme-markdown/md';
+    import md from 'babel-plugin-transform-jsxtreme-markdown/md';
     const foo = md\`
       # Title
       This is **bold.**
@@ -51,7 +51,7 @@ test('require in nested scope', () => {
   const code = `
     function x() {
       if (true) {
-        const md = require('jsxtreme-markdown/md');
+        const md = require('babel-plugin-transform-jsxtreme-markdown/md');
         const foo = md\`
           # Title
           This is **bold.**
@@ -65,7 +65,7 @@ test('require in nested scope', () => {
 
 test('alternate variable name, with broken-up nested JSX', () => {
   const code = `
-    const markit = require('jsxtreme-markdown/md');
+    const markit = require('babel-plugin-transform-jsxtreme-markdown/md');
     const text = markit\`
     This is a paragraph {{ <span className="foo"> }} with a **markdown** span inside {{ </span> }}
     {{ <div style={{ margin: 70 }}> }}
@@ -78,7 +78,7 @@ test('alternate variable name, with broken-up nested JSX', () => {
 
 test('toJsx options', () => {
   const code = `
-    import md from 'jsxtreme-markdown/md';
+    import md from 'babel-plugin-transform-jsxtreme-markdown/md';
     const foo = md\`
       This is a paragraph {{ <span className="foo">with a span inside</span> }}
       {# <div style={{ margin: 70 }}> #}
@@ -95,7 +95,7 @@ test('toJsx options', () => {
 
 test('fails with placeholders in template literals', () => {
   const code = `
-    const md = require('jsxtreme-markdown/md');
+    const md = require('babel-plugin-transform-jsxtreme-markdown/md');
     const foo = md\`
       # Title
       This is **bold.** $\{number}
@@ -108,7 +108,7 @@ test('fails with placeholders in template literals', () => {
 test('does nothing when module is not in scope', () => {
   const code = `
     function x() {
-      const md = require('jsxtreme-markdown/md');
+      const md = require('babel-plugin-transform-jsxtreme-markdown/md');
     }
     const foo = md\`
       # Title
@@ -122,7 +122,7 @@ test('does nothing when module is not in scope', () => {
 test('does not add React to scope when it is already required', () => {
   const code = `
     const React = require('react');
-    const md = require('jsxtreme-markdown/md');
+    const md = require('babel-plugin-transform-jsxtreme-markdown/md');
     const foo = md\`
       # Title
       This is **bold.**
@@ -135,7 +135,7 @@ test('does not add React to scope when it is already required', () => {
 test('does not add React to scope when it is already imported', () => {
   const code = `
     import React from 'react';
-    import md from 'jsxtreme-markdown/md';
+    import md from 'babel-plugin-transform-jsxtreme-markdown/md';
     const foo = md\`
       # Title
       This is **bold.**

--- a/packages/jsxtreme-markdown/README.md
+++ b/packages/jsxtreme-markdown/README.md
@@ -108,6 +108,8 @@ Delimiters set off interpolated JS and JSX from the Markdown text.
 Customize them by passing an array with two strings, one for the opener, one for the closer.
 For example: `['{%', '%}']`.
 
+**Note: Do not use delimiters which could clash with JS (`${}`) or JSX (`{}`).**
+
 ##### escapeDelimiter
 
 Type: `string`.

--- a/packages/jsxtreme-markdown/package.json
+++ b/packages/jsxtreme-markdown/package.json
@@ -40,6 +40,7 @@
     "remark-parse": "^5.0.0",
     "remark-rehype": "^3.0.0",
     "stringify-object": "^3.2.2",
+    "strip-indent": "^2.0.0",
     "unified": "^6.1.6",
     "unist-util-visit": "^1.3.0"
   },
@@ -49,8 +50,7 @@
     "mkdirp": "^0.5.1",
     "pify": "^3.0.0",
     "react": "^16.3.0",
-    "react-dom": "^16.2.0",
-    "strip-indent": "^2.0.0"
+    "react-dom": "^16.2.0"
   },
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
This fixes the following issues
- npm package `strip-indent` was being used as a dev dependency.
- The default fake package was `jsxtreme-markdown/md` and not `babel-plugin-transform-jsxtreme-markdown/md`.
- No warning about clashing of delimiters.


(closes https://github.com/mapbox/jsxtreme-markdown/issues/48)