### PR TITLE
strip-indent is a dependency, not a devDependency

### DIFF
--- a/packages/jsxtreme-markdown/package.json
+++ b/packages/jsxtreme-markdown/package.json
@@ -40,6 +40,7 @@
     "remark-parse": "^5.0.0",
     "remark-rehype": "^3.0.0",
     "stringify-object": "^3.2.2",
+    "strip-indent": "^2.0.0",
     "unified": "^6.1.6",
     "unist-util-visit": "^1.3.0"
   },
@@ -49,8 +50,7 @@
     "mkdirp": "^0.5.1",
     "pify": "^3.0.0",
     "react": "^16.3.0",
-    "react-dom": "^16.2.0",
-    "strip-indent": "^2.0.0"
+    "react-dom": "^16.2.0"
   },
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
This package is used in [to-jsx.js](https://github.com/mapbox/jsxtreme-markdown/blob/03ff38dff5babc385ba78781a73e8b40ce7feeb0/packages/jsxtreme-markdown/lib/to-jsx.js#L3).