### PR TITLE
No production prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+.eslintignore

--- a/package-lock.json
+++ b/package-lock.json
@@ -11938,9 +11938,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.11.1.tgz",
-			"integrity": "sha512-T/KD65Ot0PB97xTrG8afQ46x3oiVhnfGjGESSI9NWYcG92+OUPZKkwHqGWXH2t9jK1crnQjubECW0FuOth+hxw==",
+			"version": "1.13.7",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.7.tgz",
+			"integrity": "sha512-KIU72UmYPGk4MujZGYMFwinB7lOf2LsDNGSOC8ufevsrPLISrZbNJlWstRi3m0AMuszbH+EFSQ/r6w56RSPK6w==",
 			"dev": true
 		},
 		"pretty-format": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "jest": "^23.1.0",
     "lerna": "^2.9.0",
     "lint-staged": "^7.0.4",
-    "prettier": "^1.11.1",
+    "prettier": "1.13.7",
     "webpack": "^3.4.1",
     "webpack-dev-server": "^2.6.1",
     "webpack-parallel-uglify-plugin": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build-repl": "PRODUCTION=true webpack --config repl/webpack.config.js",
     "lint": "eslint .",
     "test-jest": "jest",
-    "format": "prettier --write 'packages/**/!(node_modules|dist)**/*.js'",
+    "format": "prettier --write '**/*.js'",
     "postinstall": "lerna bootstrap",
     "precommit": "lint-staged",
     "pretest": "npm run lint",

--- a/packages/babel-plugin-transform-jsxtreme-markdown/template-tag-macro.js
+++ b/packages/babel-plugin-transform-jsxtreme-markdown/template-tag-macro.js
@@ -15,8 +15,9 @@ module.exports = function templateTagMacro(defaultPackageName, applyTransform) {
         throw parentTemplateExpression
           .get('quasi.expressions.0')
           .buildCodeFrameError(
-            `Placeholders are not supported inside "${parentTemplateExpression
-              .node.tag.name}" tagged template literals`
+            `Placeholders are not supported inside "${
+              parentTemplateExpression.node.tag.name
+            }" tagged template literals`
           );
       }
     };

--- a/packages/jsxtreme-markdown/CHANGELOG.md
+++ b/packages/jsxtreme-markdown/CHANGELOG.md
@@ -1,5 +1,9 @@
 # jsxtreme-markdown changelog
 
+## HEAD
+
+- [Fix] Don't use Prettier to format component module templates. They won't be as pretty for debugging, but it's worth it to remove the production dependency on Prettier.
+
 ## 0.9.1
 
 - [Fix] `strip-indent` is a real dependency, not a devDepedency.

--- a/packages/jsxtreme-markdown/README.md
+++ b/packages/jsxtreme-markdown/README.md
@@ -61,7 +61,7 @@ const markdown = `
 `;
 
 const jsx = jsxtremeMarkdown.toJsx(markdown);
-console.log(prettier.format(jsx));
+console.log(prettier.format(jsx, { parser: 'babylon' }));
 
 /*
 <div>

--- a/packages/jsxtreme-markdown/lib/parseable-placeholders.js
+++ b/packages/jsxtreme-markdown/lib/parseable-placeholders.js
@@ -85,7 +85,9 @@ module.exports = (input, delimiters, escapeDelimiter) => {
             ? delimiterBalancedMatch.start + index
             : delimiterBalancedMatch.end + index + endDelimiter.length - 1;
           const position = lineColumn(input, errorIndex);
-          const message = `<${tagName}> is a block-level element. Interpolated tags for block-element JSX elements should be separated from surrounding Markdown by newlines. (${position.line}:${position.col})`;
+          const message = `<${tagName}> is a block-level element. Interpolated tags for block-element JSX elements should be separated from surrounding Markdown by newlines. (${
+            position.line
+          }:${position.col})`;
           const error = new Error(message);
           error.code = 'BADBLOCK';
           error.position = position;

--- a/packages/jsxtreme-markdown/lib/templates/default.js
+++ b/packages/jsxtreme-markdown/lib/templates/default.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const _ = require('lodash');
-const prettier = require('prettier');
 const stringifyObject = require('stringify-object');
 
 module.exports = data => {
@@ -40,5 +39,5 @@ module.exports = data => {
     }
   `;
 
-  return prettier.format(js);
+  return js;
 };

--- a/packages/jsxtreme-markdown/package.json
+++ b/packages/jsxtreme-markdown/package.json
@@ -35,7 +35,6 @@
     "lodash": "^4.17.5",
     "mdast-util-to-string": "^1.0.4",
     "pascal-case": "^2.0.1",
-    "prettier": "^1.11.1",
     "rehype-raw": "^2.0.0",
     "remark-parse": "^5.0.0",
     "remark-rehype": "^3.0.0",

--- a/packages/jsxtreme-markdown/test/__snapshots__/to-component-module.test.js.snap
+++ b/packages/jsxtreme-markdown/test/__snapshots__/to-component-module.test.js.snap
@@ -1,29 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`toComponentModule default options 1`] = `
-"/*---
+"
+    /*---
 title: Everything is ok
 ---*/
-import React from \\"react\\";
-
-const frontMatter = {
-  title: \\"Everything is ok\\"
+    import React from 'react';
+    
+    const frontMatter = {
+	title: 'Everything is ok'
 };
 
-export default class MarkdownReact extends React.PureComponent {
-  render() {
-    const props = this.props;
-    return (
-      <div>
-        <h1>{frontMatter.title}</h1>
-        <p>
-          And a <strong>special</strong> number: {props.number}.
-        </p>
-      </div>
-    );
-  }
-}
-"
+    export default class MarkdownReact extends React.PureComponent {
+      render() {
+        const props = this.props;
+        return <div><h1>{frontMatter.title}</h1>
+<p>And a <strong>special</strong> number: {props.number}.</p></div>;
+      }
+    }
+  "
 `;
 
 exports[`toComponentModule default options produce valid module 1`] = `
@@ -34,40 +29,36 @@ exports[`toComponentModule default options produce valid module 1`] = `
 `;
 
 exports[`toComponentModule default options with prependJs in front matter 1`] = `
-"/*---
+"
+    /*---
 title: Everything is ok
 prependJs:
   - \\"const Timer = require('./timer')\\"
   - \\"const Watcher = require('./watcher').Watcher\\"
 ---*/
-import React from \\"react\\";
-const Timer = require(\\"./timer\\");
-const Watcher = require(\\"./watcher\\").Watcher;
+    import React from 'react';
+    const Timer = require('./timer')
+const Watcher = require('./watcher').Watcher
 
-const frontMatter = {
-  title: \\"Everything is ok\\"
+    const frontMatter = {
+	title: 'Everything is ok'
 };
 
-export default class MarkdownReact extends React.PureComponent {
-  render() {
-    const props = this.props;
-    return (
-      <div>
-        <h1>{frontMatter.title}</h1>
-        <p>Some introductory text.</p>
-        <Watcher />
-        <p>
-          This paragraph includes a <Timer />.
-        </p>
-      </div>
-    );
-  }
-}
-"
+    export default class MarkdownReact extends React.PureComponent {
+      render() {
+        const props = this.props;
+        return <div><h1>{frontMatter.title}</h1>
+<p>Some introductory text.</p>
+<Watcher />
+<p>This paragraph includes a <Timer />.</p></div>;
+      }
+    }
+  "
 `;
 
 exports[`toComponentModule documentation example, with wrapper front matter 1`] = `
-"/*---
+"
+    /*---
 wrapper: '../wrapper'
 prependJs:
   - \\"import Timer from './timer'\\"
@@ -75,116 +66,102 @@ prependJs:
 title: Everything is ok
 quantity: 834
 ---*/
-import React from \\"react\\";
-import Timer from \\"./timer\\";
-import { Watcher } from \\"./watcher\\";
-import Wrapper from \\"../wrapper\\";
+    import React from 'react';
+    import Timer from './timer'
+import { Watcher } from './watcher'
+import Wrapper from '../wrapper';
 
-const frontMatter = {
-  title: \\"Everything is ok\\",
-  quantity: 834
+    const frontMatter = {
+	title: 'Everything is ok',
+	quantity: 834
 };
 
-export default class MarkdownReact extends React.PureComponent {
-  render() {
-    const props = this.props;
-    return (
-      <Wrapper {...props} frontMatter={frontMatter}>
-        <div>
-          <h1>{frontMatter.title}</h1>
-          <p>Some introductory text. The quantity is {frontMatter.quantity}</p>
-          <Watcher />
-          <p>
-            This paragraph includes a <Timer />.
-          </p>
-          <p>This component also accepts a \\"foo\\" prop: {props.foo}</p>
-        </div>
-      </Wrapper>
-    );
-  }
-}
-"
+    export default class MarkdownReact extends React.PureComponent {
+      render() {
+        const props = this.props;
+        return <Wrapper {...props} frontMatter={frontMatter}><div><h1>{frontMatter.title}</h1>
+<p>Some introductory text. The quantity is {frontMatter.quantity}</p>
+<Watcher />
+<p>This paragraph includes a <Timer />.</p>
+<p>This component also accepts a \\"foo\\" prop: {props.foo}</p></div></Wrapper>;
+      }
+    }
+  "
 `;
 
 exports[`toComponentModule non-string primitives in front matter 1`] = `
-"/*---
+"
+    /*---
 count: 7
 isHonest: false
 ---*/
-import React from \\"react\\";
-
-const frontMatter = {
-  count: 7,
-  isHonest: false
+    import React from 'react';
+    
+    const frontMatter = {
+	count: 7,
+	isHonest: false
 };
 
-export default class MarkdownReact extends React.PureComponent {
-  render() {
-    const props = this.props;
-    return (
-      <div>
-        <p>count: {frontMatter.count}</p>
-        <p>isHonest: {frontMatter.isHonest}</p>
-      </div>
-    );
-  }
-}
-"
+    export default class MarkdownReact extends React.PureComponent {
+      render() {
+        const props = this.props;
+        return <div><p>count: {frontMatter.count}</p>
+<p>isHonest: {frontMatter.isHonest}</p></div>;
+      }
+    }
+  "
 `;
 
 exports[`toComponentModule options.headings 1`] = `
-"/*---
+"
+    /*---
 title: Everything is ok
 ---*/
-import React from \\"react\\";
-
-const frontMatter = {
-  title: \\"Everything is ok\\",
-  headings: [
-    {
-      text: \\"First heading\\",
-      slug: \\"first-heading\\",
-      level: 1
-    },
-    {
-      text: \\"Two\\",
-      slug: \\"two\\",
-      level: 2
-    },
-    {
-      text: \\"Two\\",
-      slug: \\"two-1\\",
-      level: 2
-    },
-    {
-      text: \\"Third heading, great\\",
-      slug: \\"third-heading-great\\",
-      level: 3
-    },
-    {
-      text: \\"With i89 interpolation\\",
-      slug: \\"with-i89-interpolation\\",
-      level: 1
-    }
-  ]
+    import React from 'react';
+    
+    const frontMatter = {
+	title: 'Everything is ok',
+	headings: [
+		{
+			text: 'First heading',
+			slug: 'first-heading',
+			level: 1
+		},
+		{
+			text: 'Two',
+			slug: 'two',
+			level: 2
+		},
+		{
+			text: 'Two',
+			slug: 'two-1',
+			level: 2
+		},
+		{
+			text: 'Third heading, great',
+			slug: 'third-heading-great',
+			level: 3
+		},
+		{
+			text: 'With i89 interpolation',
+			slug: 'with-i89-interpolation',
+			level: 1
+		}
+	]
 };
 
-export default class MarkdownReact extends React.PureComponent {
-  render() {
-    const props = this.props;
-    return (
-      <div>
-        <h1 id=\\"first-heading\\">First heading</h1>
-        <p>Some introductory text.</p>
-        <h2 id=\\"two\\">Two</h2>
-        <h2 id=\\"two-1\\">Two</h2>
-        <h3 id=\\"third-heading-great\\">Third heading, great</h3>
-        <h1 id=\\"with-i89-interpolation\\">With {3} interpolation</h1>
-      </div>
-    );
-  }
-}
-"
+    export default class MarkdownReact extends React.PureComponent {
+      render() {
+        const props = this.props;
+        return <div><h1 id=\\"first-heading\\">First heading</h1>
+<p>Some introductory text.</p>
+<h2 id=\\"two\\">Two</h2>
+<h2 id=\\"two-1\\">Two</h2>
+<h3 id=\\"third-heading-great\\">Third heading, great</h3>
+<h1 id=\\"with-i89-interpolation\\">With {3} interpolation</h1></div>;
+      }
+    }
+  "
 `;
 
 exports[`toComponentModule options.headings 2`] = `
@@ -199,51 +176,49 @@ exports[`toComponentModule options.headings 2`] = `
 `;
 
 exports[`toComponentModule options.headings README example 1`] = `
-"import React from \\"react\\";
-
-const frontMatter = {
-  headings: [
-    {
-      text: \\"One\\",
-      slug: \\"one\\",
-      level: 1
-    },
-    {
-      text: \\"Two\\",
-      slug: \\"two\\",
-      level: 2
-    },
-    {
-      text: \\"Third-level heading\\",
-      slug: \\"third-level-heading\\",
-      level: 3
-    },
-    {
-      text: \\"Two\\",
-      slug: \\"two-1\\",
-      level: 2
-    }
-  ]
+"
+    
+    import React from 'react';
+    
+    const frontMatter = {
+	headings: [
+		{
+			text: 'One',
+			slug: 'one',
+			level: 1
+		},
+		{
+			text: 'Two',
+			slug: 'two',
+			level: 2
+		},
+		{
+			text: 'Third-level heading',
+			slug: 'third-level-heading',
+			level: 3
+		},
+		{
+			text: 'Two',
+			slug: 'two-1',
+			level: 2
+		}
+	]
 };
 
-export default class MarkdownReact extends React.PureComponent {
-  render() {
-    const props = this.props;
-    return (
-      <div>
-        <h1 id=\\"one\\">One</h1>
-        <p>Text.</p>
-        <h2 id=\\"two\\">Two</h2>
-        <p>Some more text.</p>
-        <h3 id=\\"third-level-heading\\">Third-level heading</h3>
-        <p>Yet more.</p>
-        <h2 id=\\"two-1\\">Two</h2>
-        <p>A section with a duplicate title.</p>
-      </div>
-    );
-  }
-}
-"
+    export default class MarkdownReact extends React.PureComponent {
+      render() {
+        const props = this.props;
+        return <div><h1 id=\\"one\\">One</h1>
+<p>Text.</p>
+<h2 id=\\"two\\">Two</h2>
+<p>Some more text.</p>
+<h3 id=\\"third-level-heading\\">Third-level heading</h3>
+<p>Yet more.</p>
+<h2 id=\\"two-1\\">Two</h2>
+<p>A section with a duplicate title.</p></div>;
+      }
+    }
+  "
 `;
 
 exports[`toComponentModule options.headings README example 2`] = `
@@ -260,29 +235,31 @@ exports[`toComponentModule options.headings README example 2`] = `
 `;
 
 exports[`toComponentModule options.name 1`] = `
-"import React from \\"react\\";
-
-const frontMatter = {};
-
-export default class MySpecialName extends React.PureComponent {
-  render() {
-    const props = this.props;
-    return <h1>Title</h1>;
-  }
-}
 "
+    
+    import React from 'react';
+    
+    const frontMatter = {};
+
+    export default class MySpecialName extends React.PureComponent {
+      render() {
+        const props = this.props;
+        return <h1>Title</h1>;
+      }
+    }
+  "
 `;
 
 exports[`toComponentModule options.precompile = true 1`] = `
-"\\"use strict\\";
+"'use strict';
 
 Object.defineProperty(exports, \\"__esModule\\", {
-  value: true
+    value: true
 });
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if (\\"value\\" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-var _react = require(\\"react\\");
+var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
@@ -292,46 +269,47 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError(\\"this hasn't been initialised - super() hasn't been called\\"); } return call && (typeof call === \\"object\\" || typeof call === \\"function\\") ? call : self; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; } /*---
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               title: Everything is ok
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               ---*/
+function _inherits(subClass, superClass) { if (typeof superClass !== \\"function\\" && superClass !== null) { throw new TypeError(\\"Super expression must either be null or a function, not \\" + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+/*---
+title: Everything is ok
+---*/
 
 
 var frontMatter = {
-  title: \\"Everything is ok\\"
+    title: 'Everything is ok'
 };
 
 var MarkdownReact = function (_React$PureComponent) {
-  _inherits(MarkdownReact, _React$PureComponent);
+    _inherits(MarkdownReact, _React$PureComponent);
 
-  function MarkdownReact() {
-    _classCallCheck(this, MarkdownReact);
+    function MarkdownReact() {
+        _classCallCheck(this, MarkdownReact);
 
-    return _possibleConstructorReturn(this, (MarkdownReact.__proto__ || Object.getPrototypeOf(MarkdownReact)).apply(this, arguments));
-  }
-
-  _createClass(MarkdownReact, [{
-    key: \\"render\\",
-    value: function render() {
-      var props = this.props;
-      return _react2.default.createElement(
-        \\"div\\",
-        null,
-        _react2.default.createElement(
-          \\"h1\\",
-          null,
-          frontMatter.title
-        ),
-        _react2.default.createElement(
-          \\"p\\",
-          null,
-          \\"Some introductory text.\\"
-        )
-      );
+        return _possibleConstructorReturn(this, (MarkdownReact.__proto__ || Object.getPrototypeOf(MarkdownReact)).apply(this, arguments));
     }
-  }]);
 
-  return MarkdownReact;
+    _createClass(MarkdownReact, [{
+        key: 'render',
+        value: function render() {
+            var props = this.props;
+            return _react2.default.createElement(
+                'div',
+                null,
+                _react2.default.createElement(
+                    'h1',
+                    null,
+                    frontMatter.title
+                ),
+                _react2.default.createElement(
+                    'p',
+                    null,
+                    'Some introductory text.'
+                )
+            );
+        }
+    }]);
+
+    return MarkdownReact;
 }(_react2.default.PureComponent);
 
 exports.default = MarkdownReact;"
@@ -345,23 +323,24 @@ exports[`toComponentModule options.precompile = true 2`] = `
 `;
 
 exports[`toComponentModule options.prependJs 1`] = `
-"/*---
+"
+    /*---
 title: Everything is ok
 ---*/
-import React from \\"react\\";
-import { Watcher } from \\"./watcher\\";
+    import React from 'react';
+    import { Watcher } from './watcher'
 
-const frontMatter = {
-  title: \\"Everything is ok\\"
+    const frontMatter = {
+	title: 'Everything is ok'
 };
 
-export default class MarkdownReact extends React.PureComponent {
-  render() {
-    const props = this.props;
-    return <Watcher />;
-  }
-}
-"
+    export default class MarkdownReact extends React.PureComponent {
+      render() {
+        const props = this.props;
+        return <Watcher />;
+      }
+    }
+  "
 `;
 
 exports[`toComponentModule options.template 1`] = `
@@ -399,38 +378,32 @@ exports[`toComponentModule options.wrapper with ES2015 default export 1`] = `
 `;
 
 exports[`toComponentModule toJsx options 1`] = `
-"/*---
+"
+    /*---
 title: Foo
 list:
   - one
   - two
 ---*/
-import React from \\"react\\";
-
-const frontMatter = {
-  title: \\"Foo\\",
-  list: [\\"one\\", \\"two\\"]
+    import React from 'react';
+    
+    const frontMatter = {
+	title: 'Foo',
+	list: [
+		'one',
+		'two'
+	]
 };
 
-export default class MarkdownReact extends React.PureComponent {
-  render() {
-    const props = this.props;
-    return (
-      <div>
-        <h1>{frontMatter.title}</h1>
-        <div className=\\"foo\\">
-          <p>
-            The default {\\"{\\"}
-            {\\"{\\"} delimiter {\\"}\\"}
-            {\\"}\\"} is ignored.
-          </p>
-        </div>
-        <pre>
-          <code className=\\"language-js\\">var x = 3;{\\"\\\\n\\"}</code>
-        </pre>
-      </div>
-    );
-  }
-}
-"
+    export default class MarkdownReact extends React.PureComponent {
+      render() {
+        const props = this.props;
+        return <div><h1>{frontMatter.title}</h1>
+<div className=\\"foo\\">
+<p>The default {\\"{\\"}{\\"{\\"} delimiter {\\"}\\"}{\\"}\\"} is ignored.</p>
+</div>
+<pre><code className=\\"language-js\\">var x = 3;{\\"\\\\n\\"}</code></pre></div>;
+      }
+    }
+  "
 `;

--- a/packages/jsxtreme-markdown/test/to-jsx.test.js
+++ b/packages/jsxtreme-markdown/test/to-jsx.test.js
@@ -11,7 +11,7 @@ describe('toJsx', () => {
     `;
 
     const jsx = toJsx(text);
-    expect(prettier.format(jsx)).toMatchSnapshot();
+    expect(format(jsx)).toMatchSnapshot();
   });
 
   test('expression inside a link url', () => {
@@ -26,7 +26,7 @@ describe('toJsx', () => {
     `;
 
     const jsx = toJsx(text);
-    expect(prettier.format(jsx)).toMatchSnapshot();
+    expect(format(jsx)).toMatchSnapshot();
   });
 
   test('expression inside a src url', () => {
@@ -41,7 +41,7 @@ describe('toJsx', () => {
     `;
 
     const jsx = toJsx(text);
-    expect(prettier.format(jsx)).toMatchSnapshot();
+    expect(format(jsx)).toMatchSnapshot();
   });
 
   test('with nested JSX', () => {
@@ -54,7 +54,7 @@ describe('toJsx', () => {
     `;
 
     const jsx = toJsx(text);
-    expect(prettier.format(jsx)).toMatchSnapshot();
+    expect(format(jsx)).toMatchSnapshot();
   });
 
   test('with broken-up nested JSX', () => {
@@ -68,7 +68,7 @@ describe('toJsx', () => {
     `;
 
     const jsx = toJsx(text);
-    expect(prettier.format(jsx)).toMatchSnapshot();
+    expect(format(jsx)).toMatchSnapshot();
   });
 
   test('with alternative delimiters', () => {
@@ -84,7 +84,7 @@ describe('toJsx', () => {
     };
 
     const jsx = toJsx(text, options);
-    expect(prettier.format(jsx)).toMatchSnapshot();
+    expect(format(jsx)).toMatchSnapshot();
   });
 
   test('syntax highlighting clashing with delimiters', () => {
@@ -96,7 +96,7 @@ describe('toJsx', () => {
       \`\`\`
     `;
     const jsx = toJsx(text);
-    expect(prettier.format(jsx)).toMatchSnapshot();
+    expect(format(jsx)).toMatchSnapshot();
   });
 
   test('documentation example', () => {
@@ -121,7 +121,7 @@ describe('toJsx', () => {
     `;
 
     const jsx = toJsx(text);
-    expect(prettier.format(jsx)).toMatchSnapshot();
+    expect(format(jsx)).toMatchSnapshot();
   });
 
   test('error on block-level element within paragraph', () => {
@@ -148,6 +148,10 @@ describe('toJsx', () => {
       | git diff     | git diff       | git diff      |
     `;
     const jsx = toJsx(text);
-    expect(prettier.format(jsx)).toMatchSnapshot();
+    expect(format(jsx)).toMatchSnapshot();
   });
 });
+
+function format(code) {
+  return prettier.format(code, { parser: 'babylon' });
+}


### PR DESCRIPTION
As stated in the changelog:

> Don't use Prettier to format component module templates. They won't be as pretty for debugging, but it's worth it to remove the production dependency on Prettier.

@lshig for review. Same as the related PRs in other repos :)