### PR TITLE
hast-util-to-jsx: Add dependency stringify-objects

### DIFF
--- a/packages/hast-util-to-jsx/package.json
+++ b/packages/hast-util-to-jsx/package.json
@@ -28,7 +28,8 @@
     "postcss-js": "^1.0.1",
     "property-information": "^3.2.0",
     "react-attr-converter": "^0.3.1",
-    "stringify-entities": "^1.3.1"
+    "stringify-entities": "^1.3.1",
+    "stringify-object": "^3.2.2"
   },
   "devDependencies": {
     "hastscript": "^3.1.0",


### PR DESCRIPTION
Thanks for the package! After I wanted to use the package I got an error, that the module "stringify-object" was missing. I guess the additional dependency in `package.json` of `hast-util-to-jsx` will fix this issue. I used the version I found in https://github.com/mapbox/jsxtreme-markdown/blob/e981cb5b25c2d6d5296fe3c48fa30b6d001c763f/packages/jsxtreme-markdown/package.json#L41 (Because of this dependency I guess my error only occurs when the package `hast-util-to-jsx` is used without the other packages). 